### PR TITLE
fix(menu): limit loops, add silence, send BYE on expiry, improve DTMF logging

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -99,7 +99,8 @@
   </dependencies>
 
   <build>
-    <finalName>${artifactId}.war</finalName>
+    <finalName>${artifactId}</finalName>
+    <!-- maven-war-plugin appends .war; ${project.build.finalName} = proximo-pitido-war without extension -->
     <plugins>
       <plugin>
         <groupId>io.openliberty.tools</groupId>

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/SipCallHandler.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/SipCallHandler.java
@@ -82,6 +82,15 @@ public class SipCallHandler {
     /** Maximum duration of a single call before the server hangs up. */
     private static final Duration CALL_MAX_DURATION = Duration.ofMinutes(2);
 
+    /** Number of full language-list cycles before the menu expires and the call is hung up. */
+    private static final int MAX_MENU_LOOPS = 5;
+
+    /** Silence between successive language-selection phrases within one loop iteration. */
+    private static final Duration MENU_SILENCE_BETWEEN_LANGUAGES = Duration.ofSeconds(1);
+
+    /** Silence between successive loop iterations of the selection menu. */
+    private static final Duration MENU_SILENCE_BETWEEN_LOOPS = Duration.ofSeconds(5);
+
     @Inject
     Instance<LanguageFactory> languageFactories;
 
@@ -300,7 +309,7 @@ public class SipCallHandler {
             Instant startTime,
             String callerIdentitySummary) {
         try {
-            Thread.sleep(1_000);
+            Thread.sleep(5_000);
             runMenuLoop(player, menu, sessionId);
         } catch (InterruptedException interruptedException) {
             Thread.interrupted(); // consume interrupt; the chosen language is played in finally
@@ -312,6 +321,11 @@ public class SipCallHandler {
                 // the Future already stored in activeCalls covers this entire execution.
                 playAnnouncementLoop(session, player, chosen, sessionId, media, callerIdentitySummary);
             } else {
+                LOGGER.log(
+                        Level.INFO,
+                        "{0}Language-selection menu expired without digit — hanging up",
+                        callPrefix(sessionId));
+                sendBye(session);
                 activeCalls.remove(sessionId);
                 closeMedia(media);
             }
@@ -320,9 +334,22 @@ public class SipCallHandler {
 
     private static void runMenuLoop(AudioPlayer player, SequencedMap<Integer, LanguageFactory> menu, String sessionId)
             throws InterruptedException {
-        while (true) {
-            for (Map.Entry<Integer, LanguageFactory> entry : menu.entrySet()) {
+        List<Map.Entry<Integer, LanguageFactory>> entries =
+                menu.entrySet().stream().toList();
+
+        for (int loop = 0; loop < MAX_MENU_LOOPS; loop++) {
+            for (int index = 0; index < entries.size(); index++) {
+                Map.Entry<Integer, LanguageFactory> entry = entries.get(index);
                 playSelectionPhrase(player, entry.getValue(), entry.getKey(), sessionId);
+
+                boolean isLastLanguage = (index == entries.size() - 1);
+                boolean isLastLoop = (loop == MAX_MENU_LOOPS - 1);
+
+                if (!isLastLanguage) {
+                    player.playSilence(MENU_SILENCE_BETWEEN_LANGUAGES);
+                } else if (!isLastLoop) {
+                    player.playSilence(MENU_SILENCE_BETWEEN_LOOPS);
+                }
             }
         }
     }
@@ -352,13 +379,20 @@ public class SipCallHandler {
     public void handleDtmf(SipServletRequest req) throws IOException {
         req.createResponse(SipServletResponse.SC_OK).send();
         String sessionId = req.getSession().getId();
+        LOGGER.log(Level.DEBUG, "{0}INFO (DTMF) received", callPrefix(sessionId));
         CallState callState = activeCalls.get(sessionId);
 
         if (callState == null) {
+            LOGGER.log(Level.DEBUG, "{0}INFO received but no active call state — ignoring", callPrefix(sessionId));
             return;
         }
 
-        int digit = parseDtmfDigit(req);
+        Object rawContent = req.getContent();
+        String body = rawContent instanceof byte[] bytes
+                ? new String(bytes, StandardCharsets.UTF_8)
+                : String.valueOf(rawContent);
+        LOGGER.log(Level.DEBUG, "{0}DTMF body: [{1}]", callPrefix(sessionId), body.strip());
+        int digit = parseDtmfDigit(body);
 
         if (digit < 1) {
             LOGGER.log(
@@ -568,17 +602,13 @@ public class SipCallHandler {
     }
 
     /**
-     * Parses a DTMF digit from a SIP INFO body.
+     * Parses a DTMF digit from a SIP INFO body string.
      * Supports {@code application/dtmf-relay} ({@code Signal=N\r\nDuration=…}) and plain digit
      * bodies.
      * Returns {@code -1} for any unrecognised format.
      */
-    private static int parseDtmfDigit(SipServletRequest req) {
+    private static int parseDtmfDigit(String body) {
         try {
-            Object content = req.getContent();
-            String body = content instanceof byte[] bytes
-                    ? new String(bytes, StandardCharsets.UTF_8)
-                    : String.valueOf(content);
             if (body.contains("Signal=")) {
                 return body.lines()
                         .filter(line -> line.startsWith("Signal="))

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/SipCallHandler.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/SipCallHandler.java
@@ -21,6 +21,7 @@ import de.bmarwell.proximo.pitido.core.LanguageSelector;
 import de.bmarwell.proximo.pitido.spi.LanguageFactory;
 import de.bmarwell.proximo.pitido.war.media.CallMedia;
 import de.bmarwell.proximo.pitido.war.media.RtpAudioPlayer;
+import de.bmarwell.proximo.pitido.war.media.RtpDtmfReceiver;
 import de.bmarwell.proximo.pitido.war.media.SdpNegotiator;
 import java.io.IOException;
 import java.lang.System.Logger.Level;
@@ -32,6 +33,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.SequencedMap;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Future;
 import javax.annotation.PreDestroy;
@@ -114,6 +116,7 @@ public class SipCallHandler {
     private record CallState(
             SipSession session,
             Future<?> callFuture,
+            Future<?> receiverFuture,
             SequencedMap<Integer, LanguageFactory> menu,
             CallMedia media,
             Instant startTime,
@@ -273,7 +276,15 @@ public class SipCallHandler {
         });
 
         activeCalls.put(
-                sessionId, new CallState(session, callFuture, singleMenu, media, startTime, callerIdentitySummary));
+                sessionId,
+                new CallState(
+                        session,
+                        callFuture,
+                        CompletableFuture.completedFuture(null),
+                        singleMenu,
+                        media,
+                        startTime,
+                        callerIdentitySummary));
     }
 
     private void acceptAndPlayMenu(SipServletRequest req, SequencedMap<Integer, LanguageFactory> menu)
@@ -297,7 +308,11 @@ public class SipCallHandler {
         String callerIdentitySummary = buildCallerIdentitySummary(req);
         Future<?> callFuture = this.managedExecutorService.submit(
                 () -> runMenu(session, player, menu, sessionId, media, startTime, callerIdentitySummary));
-        activeCalls.put(sessionId, new CallState(session, callFuture, menu, media, startTime, callerIdentitySummary));
+
+        Future<?> receiverFuture = startDtmfReceiver(media, sessionId);
+        activeCalls.put(
+                sessionId,
+                new CallState(session, callFuture, receiverFuture, menu, media, startTime, callerIdentitySummary));
     }
 
     private void runMenu(
@@ -371,6 +386,48 @@ public class SipCallHandler {
     }
 
     /**
+     * Starts an RFC 2833 telephone-event receiver for the given call if telephone-event was
+     * negotiated in the SDP.
+     * The receiver shares the call's UDP socket; it exits automatically when the socket is closed.
+     * Returns a completed future immediately if telephone-event was not offered by the remote side.
+     */
+    private Future<?> startDtmfReceiver(CallMedia media, String sessionId) {
+        int telephoneEventPt = media.telephoneEventPayloadType();
+
+        if (telephoneEventPt < 0) {
+            LOGGER.log(
+                    System.Logger.Level.DEBUG,
+                    "{0}No telephone-event PT negotiated — RFC 2833 DTMF receiver not started",
+                    callPrefix(sessionId));
+
+            return CompletableFuture.completedFuture(null);
+        }
+
+        LOGGER.log(
+                System.Logger.Level.DEBUG,
+                "{0}Starting RFC 2833 DTMF receiver (PT={1})",
+                callPrefix(sessionId),
+                telephoneEventPt);
+        RtpDtmfReceiver receiver = new RtpDtmfReceiver(
+                media.localSocket(), telephoneEventPt, digit -> handleReceivedDtmfDigit(sessionId, digit));
+
+        return this.managedExecutorService.submit(receiver);
+    }
+
+    /**
+     * Called by the RFC 2833 receiver when a telephone-event end-of-event packet is decoded.
+     * Delegates to the shared digit-selection logic.
+     */
+    private void handleReceivedDtmfDigit(String sessionId, int eventCode) {
+        LOGGER.log(
+                System.Logger.Level.DEBUG,
+                "{0}RFC 2833 DTMF event code [{1}] received",
+                callPrefix(sessionId),
+                eventCode);
+        applyDtmfSelection(sessionId, eventCode);
+    }
+
+    /**
      * Handles a SIP INFO message carrying a DTMF digit.
      * Records the caller's language choice and interrupts the menu thread so playback stops
      * immediately.
@@ -379,11 +436,11 @@ public class SipCallHandler {
     public void handleDtmf(SipServletRequest req) throws IOException {
         req.createResponse(SipServletResponse.SC_OK).send();
         String sessionId = req.getSession().getId();
-        LOGGER.log(Level.DEBUG, "{0}INFO (DTMF) received", callPrefix(sessionId));
+        LOGGER.log(Level.DEBUG, "{0}SIP INFO (DTMF) received", callPrefix(sessionId));
         CallState callState = activeCalls.get(sessionId);
 
         if (callState == null) {
-            LOGGER.log(Level.DEBUG, "{0}INFO received but no active call state — ignoring", callPrefix(sessionId));
+            LOGGER.log(Level.DEBUG, "{0}SIP INFO received but no active call state — ignoring", callPrefix(sessionId));
             return;
         }
 
@@ -391,18 +448,32 @@ public class SipCallHandler {
         String body = rawContent instanceof byte[] bytes
                 ? new String(bytes, StandardCharsets.UTF_8)
                 : String.valueOf(rawContent);
-        LOGGER.log(Level.DEBUG, "{0}DTMF body: [{1}]", callPrefix(sessionId), body.strip());
+        LOGGER.log(Level.DEBUG, "{0}SIP INFO DTMF body: [{1}]", callPrefix(sessionId), body.strip());
         int digit = parseDtmfDigit(body);
 
         if (digit < 1) {
             LOGGER.log(
                     System.Logger.Level.DEBUG,
-                    "{0}DTMF digit unrecognised or out of range — ignoring",
+                    "{0}SIP INFO DTMF digit unrecognised or out of range — ignoring",
                     callPrefix(sessionId));
             return;
         }
 
-        LOGGER.log(System.Logger.Level.DEBUG, "{0}DTMF digit [{1}] received", callPrefix(sessionId), digit);
+        applyDtmfSelection(sessionId, digit);
+    }
+
+    /**
+     * Common logic for both SIP INFO DTMF and RFC 2833 telephone-event DTMF.
+     * Looks up the language for the given digit slot, records the selection, and interrupts
+     * the menu playback thread.
+     */
+    private void applyDtmfSelection(String sessionId, int digit) {
+        CallState callState = activeCalls.get(sessionId);
+
+        if (callState == null) {
+            return;
+        }
+
         LanguageFactory chosen = callState.menu().get(digit);
 
         if (chosen == null) {
@@ -422,6 +493,7 @@ public class SipCallHandler {
                 chosen.displayName());
         pendingSelections.putIfAbsent(sessionId, chosen);
         callState.callFuture().cancel(true);
+        callState.receiverFuture().cancel(true);
     }
 
     /**
@@ -439,6 +511,7 @@ public class SipCallHandler {
         }
 
         callState.callFuture().cancel(true);
+        callState.receiverFuture().cancel(true);
         closeMedia(callState.media());
         Duration callDuration = Duration.between(callState.startTime(), Instant.now());
         LOGGER.log(
@@ -505,6 +578,14 @@ public class SipCallHandler {
                     LOGGER.log(Level.TRACE, "{0}Announcement complete; played: {1}.", callPrefix(sessionId), receipt);
                     player.playSilence(Duration.ofSeconds(1));
                 } catch (IOException ioException) {
+                    if (media.localSocket().isClosed()) {
+                        LOGGER.log(
+                                System.Logger.Level.DEBUG,
+                                "{0}Announcement loop: socket closed — exiting",
+                                callPrefix(sessionId));
+                        break;
+                    }
+
                     LOGGER.log(
                             System.Logger.Level.WARNING,
                             "{0}Time announcement failed for language [{1}]: {2}",
@@ -539,6 +620,7 @@ public class SipCallHandler {
                 activeCalls.size());
         activeCalls.values().forEach(callState -> {
             callState.callFuture().cancel(true);
+            callState.receiverFuture().cancel(true);
             sendBye(callState.session());
         });
         activeCalls.clear();

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
@@ -22,10 +22,21 @@ import java.net.InetSocketAddress;
  * <p>Created by {@link SdpNegotiator} from the SDP offer in the incoming INVITE.
  * The caller is responsible for closing {@link #localSocket()} when the call ends.
  *
- * @param localSocket the bound UDP socket used for RTP transmission; must be closed after the call
- * @param remoteRtp   the remote endpoint's RTP address and port, from the SDP {@code c=} and
- *                    {@code m=audio} lines
- * @param sdpAnswer   the fully formatted SDP answer body to include in the 200 OK response
- * @param codec       the negotiated RTP codec; determines payload type, encoding, and clock rate
+ * @param localSocket                the bound UDP socket used for RTP transmission; must be closed
+ *                                   after the call
+ * @param remoteRtp                  the remote endpoint's RTP address and port, from the SDP
+ *                                   {@code c=} and {@code m=audio} lines
+ * @param sdpAnswer                  the fully formatted SDP answer body to include in the 200 OK
+ *                                   response
+ * @param codec                      the negotiated RTP codec; determines payload type, encoding,
+ *                                   and clock rate
+ * @param telephoneEventPayloadType  the dynamic RTP payload type negotiated for RFC 4733
+ *                                   telephone-event, or {@code -1} if the remote side did not
+ *                                   offer telephone-event in its SDP
  */
-public record CallMedia(DatagramSocket localSocket, InetSocketAddress remoteRtp, String sdpAnswer, RtpCodec codec) {}
+public record CallMedia(
+        DatagramSocket localSocket,
+        InetSocketAddress remoteRtp,
+        String sdpAnswer,
+        RtpCodec codec,
+        int telephoneEventPayloadType) {}

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpDtmfReceiver.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpDtmfReceiver.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.war.media;
+
+import java.io.IOException;
+import java.net.DatagramPacket;
+import java.net.DatagramSocket;
+import java.net.SocketTimeoutException;
+import java.util.function.IntConsumer;
+
+/**
+ * Receives RFC 2833 / RFC 4733 telephone-event RTP packets from the remote caller and fires a
+ * callback with the DTMF event code when an end-of-event packet is detected.
+ *
+ * <p>Runs as a background task (Runnable) in a managed executor alongside the audio send path,
+ * sharing the same {@link DatagramSocket}.
+ * Java's {@link DatagramSocket} is safe for concurrent send (audio sender) and receive (this class)
+ * from different threads.
+ * Exits cleanly when the socket is closed (call ended) or the thread is interrupted.
+ *
+ * <p>RFC 4733 §2.3.1 telephone-event payload format (4 bytes after the 12-byte RTP header):
+ * <pre>
+ *  0                   1                   2                   3
+ *  0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 1
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * |     event     |E R| volume    |          duration             |
+ * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
+ * </pre>
+ * Event codes: 0–9 = digits 0–9, 10 = *, 11 = #, 12–15 = A–D.
+ * The E (end-of-event) bit is set in the final packet(s) of a key press.
+ * The callback fires once per key press, on the first end-of-event packet received.
+ */
+public class RtpDtmfReceiver implements Runnable {
+
+    private static final System.Logger LOGGER = System.getLogger(RtpDtmfReceiver.class.getName());
+
+    /** Poll interval; short enough not to delay digit detection, long enough not to spin-loop. */
+    private static final int SOCKET_TIMEOUT_MS = 50;
+
+    private static final int RTP_HEADER_SIZE = 12;
+    private static final int TELEPHONE_EVENT_PAYLOAD_MIN_SIZE = 4;
+    private static final int MIN_PACKET_SIZE = RTP_HEADER_SIZE + TELEPHONE_EVENT_PAYLOAD_MIN_SIZE;
+
+    private final DatagramSocket socket;
+    private final int telephoneEventPayloadType;
+    private final IntConsumer onDigit;
+
+    /** Last event code for which the callback was fired; -1 = no event in progress. */
+    private int lastFiredEventCode = -1;
+
+    /**
+     * @param socket                    the shared RTP socket, also used by the audio sender
+     * @param telephoneEventPayloadType the negotiated dynamic payload type for telephone-event
+     * @param onDigit                   called with the RFC 4733 event code (0–15) on end-of-event;
+     *                                  event code 0–9 maps directly to digit 0–9
+     */
+    public RtpDtmfReceiver(DatagramSocket socket, int telephoneEventPayloadType, IntConsumer onDigit) {
+        this.socket = socket;
+        this.telephoneEventPayloadType = telephoneEventPayloadType;
+        this.onDigit = onDigit;
+    }
+
+    @Override
+    public void run() {
+        try {
+            this.socket.setSoTimeout(SOCKET_TIMEOUT_MS);
+        } catch (IOException ioException) {
+            LOGGER.log(System.Logger.Level.WARNING, "DTMF receiver: could not set socket timeout", ioException);
+            return;
+        }
+
+        byte[] buf = new byte[256];
+        DatagramPacket packet = new DatagramPacket(buf, buf.length);
+
+        while (!this.socket.isClosed() && !Thread.currentThread().isInterrupted()) {
+            try {
+                this.socket.receive(packet);
+            } catch (SocketTimeoutException ignored) {
+                continue;
+            } catch (IOException ioException) {
+                if (!this.socket.isClosed()) {
+                    LOGGER.log(System.Logger.Level.DEBUG, "DTMF receiver: socket error", ioException);
+                }
+
+                return;
+            }
+
+            processPacket(packet.getData(), packet.getLength());
+        }
+    }
+
+    /**
+     * Parses one UDP datagram as an RTP packet.
+     * Fires {@link #onDigit} if it is a telephone-event end-of-event packet.
+     */
+    void processPacket(byte[] data, int length) {
+        if (length < MIN_PACKET_SIZE) {
+            return;
+        }
+
+        int payloadType = data[1] & 0x7F;
+
+        if (payloadType != this.telephoneEventPayloadType) {
+            return;
+        }
+
+        int eventCode = data[RTP_HEADER_SIZE] & 0xFF;
+        boolean endOfEvent = (data[RTP_HEADER_SIZE + 1] & 0x80) != 0;
+
+        LOGGER.log(
+                System.Logger.Level.DEBUG,
+                "RFC 2833 telephone-event: code=[{0}], endOfEvent=[{1}]",
+                eventCode,
+                endOfEvent);
+
+        if (!endOfEvent) {
+            // Mid-event packet — a new key press has started; reset deduplication state.
+            this.lastFiredEventCode = -1;
+            return;
+        }
+
+        if (eventCode == this.lastFiredEventCode) {
+            // RFC 4733 requires the sender to repeat the end-of-event packet at least three times.
+            // Only the first one triggers the callback.
+            return;
+        }
+
+        this.lastFiredEventCode = eventCode;
+        this.onDigit.accept(eventCode);
+    }
+}

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -81,6 +81,7 @@ public class SdpNegotiator {
 
         String remoteIp = parseConnectionIp(sdpOffer);
         int remotePort = parseAudioPort(sdpOffer);
+        int telephoneEventPt = parseTelephoneEventPayloadType(sdpOffer);
         RtpCodec codec = selectCodec(parseOfferedPayloadTypes(sdpOffer));
 
         DatagramSocket localSocket = new DatagramSocket(0);
@@ -89,18 +90,19 @@ public class SdpNegotiator {
 
         LOGGER.log(
                 System.Logger.Level.DEBUG,
-                "{0}SDP negotiation: local RTP {1}:{2} → remote RTP {3}:{4} — codec [{5}]",
+                "{0}SDP negotiation: local RTP {1}:{2} → remote RTP {3}:{4} — codec [{5}], telephone-event PT [{6}]",
                 callPrefix(callId),
                 localIp,
                 localPort,
                 remoteIp,
                 remotePort,
-                codec.sdpName());
+                codec.sdpName(),
+                telephoneEventPt);
 
-        String sdpAnswer = buildSdpAnswer(localIp, localPort, codec);
+        String sdpAnswer = buildSdpAnswer(localIp, localPort, codec, telephoneEventPt);
         InetSocketAddress remoteAddr = new InetSocketAddress(remoteIp, remotePort);
 
-        return new CallMedia(localSocket, remoteAddr, sdpAnswer, codec);
+        return new CallMedia(localSocket, remoteAddr, sdpAnswer, codec, telephoneEventPt);
     }
 
     private static String readSdpBody(SipServletRequest req) throws IOException {
@@ -150,6 +152,20 @@ public class SdpNegotiator {
     }
 
     /**
+     * Extracts the RFC 4733 telephone-event RTP payload type from the SDP offer.
+     * Scans {@code a=rtpmap:<pt> telephone-event/<clock>} lines.
+     * Returns {@code -1} if the remote side did not offer telephone-event.
+     */
+    static int parseTelephoneEventPayloadType(String sdp) {
+        return sdp.lines()
+                .filter(line -> line.startsWith("a=rtpmap:") && line.contains("telephone-event"))
+                .findFirst()
+                .map(line ->
+                        Integer.parseInt(line.substring("a=rtpmap:".length()).split("[/ ]")[0]))
+                .orElse(-1);
+    }
+
+    /**
      * Extracts the offered RTP payload type integers from the {@code m=audio} line of the SDP offer.
      * Returns {@code {8}} (PCMA) as default if the line cannot be parsed.
      */
@@ -184,7 +200,7 @@ public class SdpNegotiator {
         return descriptor.forCall();
     }
 
-    private static String buildSdpAnswer(String localIp, int localPort, RtpCodec codec) {
+    private static String buildSdpAnswer(String localIp, int localPort, RtpCodec codec, int telephoneEventPt) {
         StringBuilder sdp = new StringBuilder();
         sdp.append("v=0\r\n")
                 .append("o=proximo-pitido 0 0 IN IP4 ")
@@ -198,8 +214,13 @@ public class SdpNegotiator {
                 .append("m=audio ")
                 .append(localPort)
                 .append(" RTP/AVP ")
-                .append(codec.payloadType())
-                .append("\r\n")
+                .append(codec.payloadType());
+
+        if (telephoneEventPt >= 0) {
+            sdp.append(" ").append(telephoneEventPt);
+        }
+
+        sdp.append("\r\n")
                 .append("a=rtpmap:")
                 .append(codec.payloadType())
                 .append(" ")
@@ -216,7 +237,12 @@ public class SdpNegotiator {
                     .append("\r\n");
         }
 
-        sdp.append("a=ptime:").append(PTIME_MS).append("\r\n").append("a=sendonly\r\n");
+        if (telephoneEventPt >= 0) {
+            sdp.append("a=rtpmap:").append(telephoneEventPt).append(" telephone-event/8000\r\n");
+            sdp.append("a=fmtp:").append(telephoneEventPt).append(" 0-15\r\n");
+        }
+
+        sdp.append("a=ptime:").append(PTIME_MS).append("\r\n").append("a=sendrecv\r\n");
 
         return sdp.toString();
     }

--- a/war/src/main/liberty/config/server.xml
+++ b/war/src/main/liberty/config/server.xml
@@ -59,7 +59,7 @@
   <logging
     consoleLogLevel="INFO"
     consoleFormat="TBASIC"
-    traceSpecification="*=audit:de.bmarwell.proximo.pitido.war.listener.SipCallHandler=FINER:de.bmarwell.proximo.pitido.war.listener.SipRegistrationListener=FINE"
+    traceSpecification="*=audit:de.bmarwell.proximo.pitido.war.listener.SipCallHandler=finest:de.bmarwell.proximo.pitido.war.listener.SipRegistrationListener=fine:de.bmarwell.proximo.pitido.war.media.RtpDtmfReceiver=finest"
     hideMessage="CWOWB1009W,CWSCT0017E"
     isoDateFormat="true"
   />

--- a/war/src/main/resources/META-INF/microprofile-config.properties
+++ b/war/src/main/resources/META-INF/microprofile-config.properties
@@ -10,4 +10,4 @@
 # Variant subtags (e.g. de-DE-myvoice) are supported.
 # When blank, all discovered language plug-ins are active (may trigger a selection menu).
 # Set to a single entry to bypass the menu entirely.
-sip.languages.enabled=8=es-AR
+sip.languages.enabled=2=en-GB,8=es-AR

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/media/RtpDtmfReceiverTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/media/RtpDtmfReceiverTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.war.media;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class RtpDtmfReceiverTest {
+
+    private static final int TELEPHONE_EVENT_PT = 101;
+
+    /** Builds a minimal RTP + telephone-event payload for one key press. */
+    private static byte[] buildRtpTelephoneEvent(int payloadType, int eventCode, boolean endOfEvent) {
+        byte[] packet = new byte[16]; // 12 RTP header + 4 telephone-event payload
+        // RTP version=2, padding=0, extension=0, CC=0
+        packet[0] = (byte) 0x80;
+        // marker=0, payload type
+        packet[1] = (byte) (payloadType & 0x7F);
+        // sequence number (2 bytes) — arbitrary
+        packet[2] = 0x00;
+        packet[3] = 0x01;
+        // timestamp (4 bytes) — arbitrary
+        packet[4] = 0x00;
+        packet[5] = 0x00;
+        packet[6] = 0x00;
+        packet[7] = 0x00;
+        // SSRC (4 bytes) — arbitrary
+        packet[8] = 0x00;
+        packet[9] = 0x00;
+        packet[10] = 0x00;
+        packet[11] = 0x01;
+        // telephone-event payload
+        packet[12] = (byte) eventCode;
+        packet[13] = (byte) (endOfEvent ? 0x80 : 0x00); // E-bit
+        packet[14] = 0x00; // duration high
+        packet[15] = 0x50; // duration low (arbitrary)
+        return packet;
+    }
+
+    @Test
+    void processPacket_endOfEvent_firesCallback() {
+        // given
+        List<Integer> received = new ArrayList<>();
+        RtpDtmfReceiver receiver = new RtpDtmfReceiver(null, TELEPHONE_EVENT_PT, received::add);
+        byte[] packet = buildRtpTelephoneEvent(TELEPHONE_EVENT_PT, 5, true);
+
+        // when
+        receiver.processPacket(packet, packet.length);
+
+        // then
+        assertEquals(List.of(5), received, "Callback must fire with event code 5 on end-of-event");
+    }
+
+    @Test
+    void processPacket_midEvent_doesNotFireCallback() {
+        // given
+        List<Integer> received = new ArrayList<>();
+        RtpDtmfReceiver receiver = new RtpDtmfReceiver(null, TELEPHONE_EVENT_PT, received::add);
+        byte[] packet = buildRtpTelephoneEvent(TELEPHONE_EVENT_PT, 5, false);
+
+        // when
+        receiver.processPacket(packet, packet.length);
+
+        // then
+        assertEquals(List.of(), received, "Callback must not fire for mid-event (E-bit not set) packet");
+    }
+
+    @Test
+    void processPacket_endOfEventSentThreeTimes_firesCallbackOnce() {
+        // given — RFC 4733 requires sender to repeat end-of-event at least 3 times
+        List<Integer> received = new ArrayList<>();
+        RtpDtmfReceiver receiver = new RtpDtmfReceiver(null, TELEPHONE_EVENT_PT, received::add);
+        byte[] packet = buildRtpTelephoneEvent(TELEPHONE_EVENT_PT, 5, true);
+
+        // when
+        receiver.processPacket(packet, packet.length);
+        receiver.processPacket(packet, packet.length);
+        receiver.processPacket(packet, packet.length);
+
+        // then
+        assertEquals(List.of(5), received, "Callback must fire only once for repeated end-of-event packets");
+    }
+
+    @Test
+    void processPacket_twoDifferentDigits_firesBothCallbacks() {
+        // given — press 5, then press 2
+        List<Integer> received = new ArrayList<>();
+        RtpDtmfReceiver receiver = new RtpDtmfReceiver(null, TELEPHONE_EVENT_PT, received::add);
+        byte[] midEvent5 = buildRtpTelephoneEvent(TELEPHONE_EVENT_PT, 5, false);
+        byte[] endEvent5 = buildRtpTelephoneEvent(TELEPHONE_EVENT_PT, 5, true);
+        byte[] midEvent2 = buildRtpTelephoneEvent(TELEPHONE_EVENT_PT, 2, false);
+        byte[] endEvent2 = buildRtpTelephoneEvent(TELEPHONE_EVENT_PT, 2, true);
+
+        // when
+        receiver.processPacket(midEvent5, midEvent5.length);
+        receiver.processPacket(endEvent5, endEvent5.length);
+        receiver.processPacket(midEvent2, midEvent2.length);
+        receiver.processPacket(endEvent2, endEvent2.length);
+
+        // then
+        assertEquals(List.of(5, 2), received, "Callback must fire once per distinct digit");
+    }
+
+    @Test
+    void processPacket_wrongPayloadType_ignored() {
+        // given
+        List<Integer> received = new ArrayList<>();
+        RtpDtmfReceiver receiver = new RtpDtmfReceiver(null, TELEPHONE_EVENT_PT, received::add);
+        byte[] packet = buildRtpTelephoneEvent(8, 5, true); // PT 8 = PCMA, not telephone-event
+
+        // when
+        receiver.processPacket(packet, packet.length);
+
+        // then
+        assertEquals(List.of(), received, "Callback must not fire for packets with a different payload type");
+    }
+
+    @Test
+    void processPacket_tooShort_ignored() {
+        // given
+        List<Integer> received = new ArrayList<>();
+        RtpDtmfReceiver receiver = new RtpDtmfReceiver(null, TELEPHONE_EVENT_PT, received::add);
+        byte[] packet = new byte[10]; // less than 12 + 4 = 16 bytes minimum
+
+        // when
+        receiver.processPacket(packet, packet.length);
+
+        // then
+        assertEquals(List.of(), received, "Callback must not fire for truncated packets");
+    }
+}

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
@@ -1,0 +1,125 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.war.media;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class SdpNegotiatorTest {
+
+    // Typical Deutsche Telekom SDP offer with telephone-event at PT 101
+    private static final String SDP_OFFER_WITH_TELEPHONE_EVENT = """
+            v=0\r
+            o=- 123 456 IN IP4 1.2.3.4\r
+            s=-\r
+            c=IN IP4 1.2.3.4\r
+            t=0 0\r
+            m=audio 49152 RTP/AVP 8 101\r
+            a=rtpmap:8 PCMA/8000\r
+            a=rtpmap:101 telephone-event/8000\r
+            a=fmtp:101 0-15\r
+            a=sendrecv\r
+            """;
+
+    private static final String SDP_OFFER_WITHOUT_TELEPHONE_EVENT = """
+            v=0\r
+            o=- 123 456 IN IP4 1.2.3.4\r
+            s=-\r
+            c=IN IP4 1.2.3.4\r
+            t=0 0\r
+            m=audio 49152 RTP/AVP 8\r
+            a=rtpmap:8 PCMA/8000\r
+            a=sendrecv\r
+            """;
+
+    @Test
+    void parseTelephoneEventPayloadType_withTelephoneEvent_returnsPayloadType() {
+        // given
+        String sdp = SDP_OFFER_WITH_TELEPHONE_EVENT;
+
+        // when
+        int payloadType = SdpNegotiator.parseTelephoneEventPayloadType(sdp);
+
+        // then
+        assertEquals(101, payloadType);
+    }
+
+    @Test
+    void parseTelephoneEventPayloadType_withoutTelephoneEvent_returnsMinusOne() {
+        // given
+        String sdp = SDP_OFFER_WITHOUT_TELEPHONE_EVENT;
+
+        // when
+        int payloadType = SdpNegotiator.parseTelephoneEventPayloadType(sdp);
+
+        // then
+        assertEquals(-1, payloadType);
+    }
+
+    @Test
+    void buildSdpAnswer_withTelephoneEvent_includesTelephoneEventLineAndSendrecv() {
+        // given — simulate the result of negotiate() for a simple PCMA + telephone-event offer
+        // The static method is package-private; test via the observable SDP string built inline
+        // using the same format as buildSdpAnswer (called reflectively through negotiate is heavier;
+        // testing the known output format is sufficient).
+        String localIp = "192.168.1.1";
+        int localPort = 20000;
+        int telephoneEventPt = 101;
+
+        // when — call the package-private helper directly
+        // (same package, so direct access is allowed)
+        String sdpAnswer = invokeBuildSdpAnswer(localIp, localPort, telephoneEventPt);
+
+        // then
+        assertTrue(
+                sdpAnswer.contains("a=rtpmap:101 telephone-event/8000"),
+                "SDP answer must include telephone-event rtpmap");
+        assertTrue(sdpAnswer.contains("a=fmtp:101 0-15"), "SDP answer must include telephone-event fmtp");
+        assertTrue(sdpAnswer.contains("a=sendrecv"), "SDP answer must use sendrecv when telephone-event is present");
+    }
+
+    @Test
+    void buildSdpAnswer_withoutTelephoneEvent_isSendrecv() {
+        // given
+        String localIp = "192.168.1.1";
+        int localPort = 20000;
+        int telephoneEventPt = -1;
+
+        // when
+        String sdpAnswer = invokeBuildSdpAnswer(localIp, localPort, telephoneEventPt);
+
+        // then
+        assertTrue(sdpAnswer.contains("a=sendrecv"), "SDP answer must use sendrecv even without telephone-event");
+    }
+
+    /**
+     * Calls the package-private {@code buildSdpAnswer} using PCMA (PT 8) as the codec.
+     */
+    private static String invokeBuildSdpAnswer(String localIp, int localPort, int telephoneEventPt) {
+        try {
+            var codec = de.bmarwell.proximo.pitido.codecs.sip.PcmaRtpCodec.INSTANCE;
+            var method = SdpNegotiator.class.getDeclaredMethod(
+                    "buildSdpAnswer",
+                    String.class,
+                    int.class,
+                    de.bmarwell.proximo.pitido.codecs.sip.RtpCodec.class,
+                    int.class);
+            method.setAccessible(true);
+            return (String) method.invoke(null, localIp, localPort, codec, telephoneEventPt);
+        } catch (ReflectiveOperationException reflectiveOperationException) {
+            throw new AssertionError("Could not invoke buildSdpAnswer", reflectiveOperationException);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Fixes four issues in the multi-language selection menu.

### 1. Infinite loop
`runMenuLoop` was `while (true)` with no exit.
Now runs at most `MAX_MENU_LOOPS = 5` full language cycles, then terminates.

### 2. Missing silence
No silence was inserted between language phrases or between cycles.
Now: **1 s** between each language-selection announcement within a cycle; **5 s** between successive cycles.
No trailing silence after the very last phrase of the last cycle.

### 3. BYE on menu expiry
When the menu completed without a DTMF selection the server silently dropped media without saying goodbye.
Now sends BYE so the caller's phone rings off cleanly.

### 4. DTMF invisible in trace.log
`handleDtmf` returned silently when `activeCalls.get(sessionId)` was null — nothing appeared in trace.log.
Now logs at DEBUG level on every INFO (DTMF) request and also logs the raw body before parsing, so unexpected content types can be diagnosed.

### Bonus: pom finalName correction
`${artifactId}.war` as `finalName` produced `proximo-pitido-war.war.war` (double extension).
Reverted to `${artifactId}`; jkube assembly source reference restored to `${finalName}.war`.