### PR TITLE
fix: replace jkube with maven-antrun-plugin for Docker builds (Maven 4 compat)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -227,9 +227,9 @@
         </plugin>
 
         <plugin>
-          <groupId>org.eclipse.jkube</groupId>
-          <artifactId>kubernetes-maven-plugin</artifactId>
-          <version>1.18.2</version>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-antrun-plugin</artifactId>
+          <version>3.1.0</version>
         </plugin>
 
       </plugins>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -154,50 +154,38 @@
       <build>
         <plugins>
           <plugin>
-            <groupId>org.eclipse.jkube</groupId>
-            <artifactId>kubernetes-maven-plugin</artifactId>
-            <configuration>
-              <images>
-                <image>
-                  <name>de.bmarwell.proximo.pitido/${project.artifactId}</name>
-                  <build>
-                    <dockerFile>${project.basedir}/src/main/docker/Dockerfile</dockerFile>
-                    <assembly>
-                      <inline>
-                        <fileSets>
-                          <fileSet>
-                            <directory>${project.basedir}/src/main/liberty/config</directory>
-                            <outputDirectory>config</outputDirectory>
-                            <excludes>
-                              <exclude>server.env</exclude>
-                              <exclude>.gitignore</exclude>
-                            </excludes>
-                          </fileSet>
-                        </fileSets>
-                        <files>
-                          <file>
-                            <source>${project.build.directory}/${project.build.finalName}.war</source>
-                            <outputDirectory>.</outputDirectory>
-                          </file>
-                        </files>
-                      </inline>
-                    </assembly>
-                    <tags>
-                      <tag>latest</tag>
-                      <tag>${project.version}</tag>
-                    </tags>
-                  </build>
-                </image>
-              </images>
-              <verbose>true</verbose>
-            </configuration>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-antrun-plugin</artifactId>
             <executions>
               <execution>
                 <id>build-docker-image</id>
-                <goals>
-                  <goal>build</goal>
-                </goals>
                 <phase>package</phase>
+                <goals>
+                  <goal>run</goal>
+                </goals>
+                <configuration>
+                  <target>
+                    <mkdir dir="${project.build.directory}/docker-context/maven/config"/>
+                    <copy todir="${project.build.directory}/docker-context/maven/config">
+                      <fileset dir="${project.basedir}/src/main/liberty/config">
+                        <exclude name="server.env"/>
+                        <exclude name=".gitignore"/>
+                      </fileset>
+                    </copy>
+                    <copy file="${project.build.directory}/${project.build.finalName}.war"
+                          todir="${project.build.directory}/docker-context/maven/"/>
+                    <exec executable="docker" failonerror="true">
+                      <arg value="build"/>
+                      <arg value="-f"/>
+                      <arg value="${project.basedir}/src/main/docker/Dockerfile"/>
+                      <arg value="-t"/>
+                      <arg value="de.bmarwell.proximo.pitido/${project.artifactId}:latest"/>
+                      <arg value="-t"/>
+                      <arg value="de.bmarwell.proximo.pitido/${project.artifactId}:${project.version}"/>
+                      <arg value="${project.build.directory}/docker-context"/>
+                    </exec>
+                  </target>
+                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
## Problem

`kubernetes-maven-plugin` 1.x relies on `jansi` being available in Maven's own lib directory.
Maven 4 tightened classloader isolation so plugins can no longer access Maven-bundled classes, causing:

```
ClassNotFoundException: org.fusesource.jansi.AnsiConsole
```

This affects jkube 1.17–1.19 with Maven 4; no jkube 1.x version resolves it.

## Fix

Replace the entire `kubernetes-maven-plugin` execution in the `dockerize` profile with `maven-antrun-plugin:3.1.0`:

1. Ant `<mkdir>` + `<copy>` tasks stage liberty config and the WAR into `target/docker-context/maven/` — the exact layout the existing Dockerfile already expects.
2. Ant `<exec>` calls `docker build` directly, passing the Dockerfile path and two image tags.

The Dockerfile is **unchanged**.
`maven-antrun-plugin` has zero dependencies on `jansi` and works identically on Maven 3 and Maven 4.

## Testing

- `./mvnw -am -pl war verify` passes (normal build unaffected)
- `./mvnw -am -pl war -Pdockerize package` was verified on Maven 4.0.0-rc-5