### PR TITLE
feat: SIP_REGISTRATION_ENABLED=false for softphone / dev mode

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -141,12 +141,13 @@ OPTIONS:   ("Proximo Pitido", "DAR:From", "NEUTRAL", "", "NO_ROUTE", "0")
 |===
 |Env var |MP Config property |Description
 
-|`SIP_REGISTRAR`      |`sip.registrar`      |SIP domain of the registrar (e.g. `tel.t-online.de`, `sip.sipgate.de`)
-|`SIP_SIPID`          |`sip.sipid`          |Your SIP subscriber ID / phone number
-|`SIP_USER_ID`        |`sip.user.id`        |Auth username (often an e-mail address)
-|`SIP_USER_PASSWORD`  |`sip.user.password`  |Auth password
-|`SIP_LOCAL_HOST`     |`sip.local.host`     |LAN IP Liberty binds the SIP endpoint to
-|`SIP_PUBLIC_HOST`    |`sip.public.host`    |Public IP advertised in the Contact header (auto-detected if absent)
+|`SIP_REGISTRAR`             |`sip.registrar`             |SIP domain of the registrar (e.g. `tel.t-online.de`, `sip.sipgate.de`). Optional when registration is disabled.
+|`SIP_SIPID`                 |`sip.sipid`                 |Your SIP subscriber ID / phone number. Optional when registration is disabled.
+|`SIP_USER_ID`               |`sip.user.id`               |Auth username (often an e-mail address). Optional when registration is disabled.
+|`SIP_USER_PASSWORD`         |`sip.user.password`         |Auth password. Optional when registration is disabled.
+|`SIP_LOCAL_HOST`            |`sip.local.host`            |LAN IP Liberty binds the SIP endpoint to
+|`SIP_PUBLIC_HOST`           |`sip.public.host`           |Public IP advertised in the Contact header (auto-detected if absent)
+|`SIP_REGISTRATION_ENABLED`  |`sip.registration.enabled`  |Set to `false` to skip REGISTER entirely and accept direct calls only (softphone / dev mode). Default: `true`.
 |===
 
 `server.env` is intentionally excluded from version control (contains secrets).

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/SipRegistrationListener.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/SipRegistrationListener.java
@@ -73,24 +73,34 @@ public class SipRegistrationListener {
      */
     private final AtomicBoolean staleRetryUsed = new AtomicBoolean(false);
 
+    /**
+     * When {@code false}, the application skips SIP REGISTER entirely and accepts direct calls
+     * from softphones on the local network.
+     * All SIP credentials become optional when registration is disabled.
+     * Maps to {@code SIP_REGISTRATION_ENABLED}.
+     */
+    @Inject
+    @ConfigProperty(name = "sip.registration.enabled", defaultValue = "true")
+    boolean registrationEnabled;
+
     /** SIP domain of the registrar, e.g. {@code tel.t-online.de} or {@code sip.sipgate.de}. Maps to {@code SIP_REGISTRAR}. */
     @Inject
-    @ConfigProperty(name = "sip.registrar")
+    @ConfigProperty(name = "sip.registrar", defaultValue = "")
     String registrar;
 
     /** SIP subscriber ID / phone number used to build the SIP URI. Maps to {@code SIP_SIPID}. */
     @Inject
-    @ConfigProperty(name = "sip.sipid")
+    @ConfigProperty(name = "sip.sipid", defaultValue = "")
     String sipId;
 
     /** Authentication username (often an e-mail address). Maps to {@code SIP_USER_ID}. */
     @Inject
-    @ConfigProperty(name = "sip.user.id")
+    @ConfigProperty(name = "sip.user.id", defaultValue = "")
     String loginUserId;
 
     /** Authentication password. Maps to {@code SIP_USER_PASSWORD}. */
     @Inject
-    @ConfigProperty(name = "sip.user.password")
+    @ConfigProperty(name = "sip.user.password", defaultValue = "")
     String loginPassword;
 
     @Inject
@@ -137,6 +147,14 @@ public class SipRegistrationListener {
      * the factory is not available immediately after the delay.
      */
     public void scheduleRegistration(ServletContext sc) {
+        if (!this.registrationEnabled) {
+            LOGGER.log(
+                    System.Logger.Level.INFO,
+                    "SIP registration disabled (sip.registration.enabled=false) — "
+                            + "listening for direct calls only");
+            return;
+        }
+
         this.shuttingDown.set(false);
         this.servletContext = sc;
         this.startupRegistrationTask = this.managedScheduledExecutorService.schedule(


### PR DESCRIPTION
## What

Adds a `SIP_REGISTRATION_ENABLED` env var (MP Config: `sip.registration.enabled`, default `true`).

When set to `false`:
- `scheduleRegistration()` logs one INFO message and returns — no REGISTER is ever sent.
- All SIP credentials become optional (`defaultValue=""`) so Liberty starts without a `server.env`.
- The SIP stack still binds to port 5060; any softphone can dial the app directly.

## Why

Useful for local testing: call the app from a softphone without touching the Telekom registration or needing a real phone number configured.

## server.env for softphone mode

```
SIP_REGISTRATION_ENABLED=false
SIP_LOCAL_HOST=192.168.x.y
```

Then dial `sip:proximo@192.168.x.y:5060` from a softphone.