### PR TITLE
fix: copy WAR to /config/dropins/ so Liberty auto-deploys the SIP app

### DIFF
--- a/war/src/main/docker/Dockerfile
+++ b/war/src/main/docker/Dockerfile
@@ -4,7 +4,7 @@ COPY --chown=1001:0 maven/config/* /config/
 
 RUN features.sh
 
-COPY --chown=1001:0 maven/*.war /config/apps/
+COPY --chown=1001:0 maven/*.war /config/dropins/
 
 ENV OPENJ9_SCC=true
 RUN configure.sh


### PR DESCRIPTION
## Root cause

Liberty only auto-monitors `dropins/` for application deployment.
The `apps/` directory requires an explicit `<webApplication location="..."/>` in `server.xml` to deploy anything placed there.

The Dockerfile was copying the WAR to `/config/apps/`, so:
- `CWWKZ0058I: Monitoring dropins for applications` — only `dropins/` monitored
- WAR in `apps/` → never picked up
- No app deployment → no SIP endpoint bound → no `SipTimeServlet.init()` → no REGISTER → no incoming call handling

The container appeared healthy (Liberty said "ready to run a smarter planet") but had zero SIP functionality.

## Fix

One-line Dockerfile change: `/config/apps/` → `/config/dropins/`

## Evidence from nova

```
/config/apps/:  proximo-pitido-war.war   ← was here, never loaded
/config/dropins/:                        ← empty, monitored
```
No `CWWKZ0001I` (app installed) or `CWSIP` (SIP endpoint) messages in messages.log.