### PR TITLE
fix: rename WAR from proximo-pitido-war.war to proximo-pitido.war

### DIFF
--- a/war/pom.xml
+++ b/war/pom.xml
@@ -99,8 +99,7 @@
   </dependencies>
 
   <build>
-    <finalName>${artifactId}</finalName>
-    <!-- maven-war-plugin appends .war; ${project.build.finalName} = proximo-pitido-war without extension -->
+    <finalName>proximo-pitido</finalName>
     <plugins>
       <plugin>
         <groupId>io.openliberty.tools</groupId>


### PR DESCRIPTION
The `artifactId` is `proximo-pitido-war`, so Maven produced `proximo-pitido-war.war` — the `-war` part is redundant since Maven already appends `.war`.\n\nSet `<finalName>proximo-pitido</finalName>` in `war/pom.xml`.\n\nThe Dockerfile glob (`maven/*.war`) and the antrun copy (`${project.build.finalName}.war`) both adapt automatically — no other changes needed.