### PR TITLE
fix: install opus/spandsp native libs in Docker image

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -175,25 +175,30 @@ Logs: `war/target/wlp-usr/servers/proximo-pitido/logs/messages.log`
 Some features require native shared libraries installed on the host OS.
 Without them the feature is silently unavailable at runtime and a pure-Java fallback (where one exists) is used instead.
 
-[cols="1,2,2,2"]
+[cols="1,2,2,2,2"]
 |===
-|Library |Debian / Ubuntu |Arch Linux |Feature
+|Library |Debian / Ubuntu |Arch Linux |RHEL / UBI 9 (Docker) |Feature
 
-|`libopus0`
+|`libopus.so.0`
 |`sudo apt install libopus0`
 |`sudo pacman -S opus`
+|`microdnf install opus`
 |OGG/Opus audio decoding — *required* for the bundled language packs (Opus is the only supported format for language plug-ins)
+
+|`libspandsp.so.2`
+|`sudo apt install libspandsp2`
+|`sudo pacman -S spandsp`
+a|Enable EPEL first, then: +
+`rpm -i https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm` +
+`microdnf install spandsp`
+|G.722 HD Voice (50–7 000 Hz) wideband codec.
+`G722RtpCodec.isAvailable()` returns `false` when absent and the call falls back to PCMA.
 
 |`libsoxr0`
 |`sudo apt install libsoxr0`
 |`sudo pacman -S libsoxr`
+|_not yet packaged in UBI_
 |High-quality stereo-to-mono channel mixing (sample-rate-aware resampling).
 Falls back to the built-in Java mixer when absent.
 The FFM binding is not yet implemented; the library is detected but the Java path is used unconditionally for now.
-
-|`libg72x` _(future)_
-|not yet packaged — build from source
-|`yay -S libg72x` _(AUR)_
-|G.722 HD Voice (50–7 000 Hz) codec.
-Not yet implemented; `G722RtpCodec.isAvailable()` always returns `false`.
 |===

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/G722RtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/G722RtpCodec.java
@@ -44,6 +44,7 @@ import javax.enterprise.context.ApplicationScoped;
  * <ul>
  *   <li>Debian / Ubuntu: {@code apt install libspandsp2}</li>
  *   <li>Arch Linux: {@code pacman -S spandsp}</li>
+ *   <li>RHEL / UBI 9: {@code rpm -i https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm && microdnf install spandsp}</li>
  * </ul>
  *
  * <p>The FFM binding calls two functions:
@@ -140,7 +141,7 @@ public final class G722RtpCodec implements RtpCodec {
     }
 
     /**
-     * Probes for {@code libspandsp.so} and binds the required FFM method handles.
+     * Probes for {@code libspandsp.so.2} and binds the required FFM method handles.
      *
      * <p>Called once by the CDI container after construction.
      * Sets {@link #available} to {@code true} when the library is found and all symbols resolve.
@@ -150,7 +151,7 @@ public final class G722RtpCodec implements RtpCodec {
     @SuppressWarnings("restricted") // SymbolLookup.libraryLookup is FFM restricted — intentional use
     void probe() {
         try {
-            SymbolLookup spandsp = SymbolLookup.libraryLookup("libspandsp.so", Arena.global());
+            SymbolLookup spandsp = SymbolLookup.libraryLookup("libspandsp.so.2", Arena.global());
             Linker linker = Linker.nativeLinker();
 
             this.g722EncodeInitHandle = linker.downcallHandle(

--- a/war/src/main/docker/Dockerfile
+++ b/war/src/main/docker/Dockerfile
@@ -1,5 +1,15 @@
 FROM icr.io/appcafe/open-liberty:kernel-slim-java25-openj9-ubi-minimal
 
+# Install native libraries required for audio codecs:
+#   opus      → libopus.so.0  (OGG/Opus audio decoding via FFM)
+#   spandsp   → libspandsp.so.2  (G.722 wideband encoding via FFM)
+# spandsp is in EPEL 9, not in standard UBI repos — add EPEL first.
+USER root
+RUN rpm -i https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
+    && microdnf install -y --nodocs opus spandsp \
+    && microdnf clean all
+USER 1001
+
 COPY --chown=1001:0 maven/config/* /config/
 
 RUN features.sh


### PR DESCRIPTION
## Problem

The Docker image was missing native libraries needed for audio codecs:
- `libopus.so.0` — required for OGG/Opus audio decoding (language packs)
- `libspandsp.so.2` — required for G.722 wideband encoding

Both packages are absent from the UBI 9 base image used by OpenLiberty.
`libspandsp` is not in any standard UBI repo and requires EPEL 9.

## Changes

### Dockerfile
Adds a `USER root` block before the first `COPY` to install native libs:
```
rpm -i <epel-9>
microdnf install -y --nodocs opus spandsp
microdnf clean all
```

### G722RtpCodec.java
Fixes `SymbolLookup.libraryLookup("libspandsp.so", ...)` → `"libspandsp.so.2"`.
The unversioned `.so` symlink is only provided by the `-devel` package.
Using the versioned name works on Debian (`libspandsp2`), Arch (`spandsp`), and RHEL/UBI 9 (`spandsp` via EPEL).

### README.adoc
- Adds RHEL / UBI 9 column to the native-libs table
- Replaces the placeholder `libg72x` row with the correct `libspandsp` row (G.722 is now implemented)
- Documents the EPEL install procedure