### PR TITLE
fix: remove stale libg72x Javadoc reference and add stale-nonce retry test

### DIFF
--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/RtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/RtpCodec.java
@@ -39,7 +39,7 @@ public interface RtpCodec {
      * Returns {@code true} if this codec can be used on the current host.
      *
      * <p>Pure-Java codecs (e.g. PCMA) always return {@code true}.
-     * Native-library codecs (e.g. a future G.722 via libg72x) return {@code false} when the
+     * Native-library codecs (e.g. {@link de.bmarwell.proximo.pitido.codecs.sip.G722RtpCodec} via libspandsp) return {@code false} when the
      * required library is not installed.
      */
     boolean isAvailable();

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/SipRegistrationListenerTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/SipRegistrationListenerTest.java
@@ -79,6 +79,16 @@ class SipRegistrationListenerTest {
     }
 
     @Test
+    void canRetryAfterStale_returnsTrueFirstTime_thenFalse() {
+        // given
+        var listener = new SipRegistrationListener();
+
+        // when / then: exactly one stale retry is permitted
+        assertTrue(listener.canRetryAfterStale());
+        assertFalse(listener.canRetryAfterStale());
+    }
+
+    @Test
     void resetForReRegistration_allowsStaleRetryAgain() {
         // given: a previous registration cycle consumed the stale-retry allowance
         var listener = new SipRegistrationListener();


### PR DESCRIPTION
Closes #28, closes #32

## Commits

### 1. fix: remove stale libg72x reference in RtpCodec Javadoc (#28)

`RtpCodec.isAvailable()` Javadoc still referenced `libg72x` as a "future G.722" example.
G.722 is now fully implemented via `libspandsp` in `G722RtpCodec`.
Updated the example to reference the concrete implementation directly.

### 2. test: canRetryAfterStale allows exactly one stale-nonce retry (#32)

Added `canRetryAfterStale_returnsTrueFirstTime_thenFalse` to `SipRegistrationListenerTest`.
Verifies the core `AtomicBoolean.compareAndSet` behaviour: exactly one stale retry is
permitted per registration cycle; subsequent calls return `false` to prevent infinite loops.