### PR TITLE
feat: RtpCodec extends AutoCloseable; G722RtpCodec closes per-call arena

### DIFF
--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/G722RtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/G722RtpCodec.java
@@ -61,10 +61,9 @@ import javax.enterprise.context.ApplicationScoped;
  * would corrupt audio.
  * This {@code @ApplicationScoped} CDI bean acts as a factory: {@link #forCall()} allocates a
  * fresh {@link Arena} and {@code g722_encode_state_t} segment for each call leg and returns a
- * plain (non-CDI) {@code G722RtpCodec} instance.
- *
- * <p>TODO: extend {@link RtpCodec} with {@link AutoCloseable} so per-call arenas are released
- * promptly when the call ends rather than relying on GC.
+ * plain (non-CDI) {@code G722RtpCodec} instance that implements {@link AutoCloseable}.
+ * Callers must invoke {@link #close()} when the call ends to release the native encoder state
+ * promptly; {@link de.bmarwell.proximo.pitido.war.media.CallSessionManager} handles this.
  *
  * <h2>G.729 — will not be implemented</h2>
  *
@@ -104,11 +103,11 @@ public final class G722RtpCodec implements RtpCodec {
     // Per-call instance fields — null in the CDI factory bean.
 
     /**
-     * GC-managed arena owning the native encoder state for this call leg.
+     * Confined arena owning the native encoder state for this call leg.
      * {@code null} in the CDI factory bean.
      *
-     * <p>Using {@link Arena#ofAuto()} avoids resource leaks until {@link RtpCodec} is extended
-     * with {@link AutoCloseable} and the caller can close it explicitly.
+     * <p>Closed explicitly by {@link #close()} when the call ends, releasing the native
+     * encoder state immediately rather than waiting for GC.
      */
     private final Arena callArena;
 
@@ -208,7 +207,7 @@ public final class G722RtpCodec implements RtpCodec {
      */
     @Override
     public RtpCodec forCall() {
-        Arena arena = Arena.ofAuto();
+        Arena arena = Arena.ofConfined();
         MemorySegment state = arena.allocate(STATE_SIZE, STATE_ALIGN);
         MemorySegment initialised = invokeEncodeInit(state);
 
@@ -284,6 +283,18 @@ public final class G722RtpCodec implements RtpCodec {
     @Override
     public String fmtpParams() {
         return "";
+    }
+
+    /**
+     * Closes the confined arena, releasing the native {@code g722_encode_state_t} segment.
+     *
+     * <p>A no-op when called on the CDI factory bean (whose {@link #callArena} is {@code null}).
+     */
+    @Override
+    public void close() {
+        if (this.callArena != null) {
+            this.callArena.close();
+        }
     }
 
     private MemorySegment invokeEncodeInit(MemorySegment state) {

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/RtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/RtpCodec.java
@@ -33,7 +33,7 @@ import java.io.IOException;
  * {@link de.bmarwell.proximo.pitido.war.media.SdpNegotiator} discovers all beans via CDI
  * {@code Instance<RtpCodec>} and filters by availability and preference.
  */
-public interface RtpCodec {
+public interface RtpCodec extends AutoCloseable {
 
     /**
      * Returns {@code true} if this codec can be used on the current host.
@@ -130,4 +130,17 @@ public interface RtpCodec {
      * Does not include the leading {@code "a=fmtp:<pt> "} prefix.
      */
     String fmtpParams();
+
+    /**
+     * Releases any native resources held by this per-call codec instance.
+     *
+     * <p>Stateless codecs (e.g. PCMA) return {@code this} from {@link #forCall()} and must not
+     * be closed; the default implementation is a no-op.
+     * Stateful per-call codecs (e.g. G.722) override this to release their native {@link Arena}.
+     * {@link de.bmarwell.proximo.pitido.war.media.CallSessionManager} calls this when the call ends.
+     */
+    @Override
+    default void close() {
+        // no-op for stateless codecs (e.g. PCMA) whose forCall() returns the shared CDI singleton
+    }
 }

--- a/codecs/sip/src/test/java/de/bmarwell/proximo/pitido/codecs/sip/G722RtpCodecTest.java
+++ b/codecs/sip/src/test/java/de/bmarwell/proximo/pitido/codecs/sip/G722RtpCodecTest.java
@@ -91,6 +91,32 @@ class G722RtpCodecTest {
     // -------------------------------------------------------------------------
 
     @Test
+    void closeOnFactoryBean_isNoOp() {
+        // given: a fresh factory bean (no callArena)
+        var factory = new G722RtpCodec();
+
+        // when / then: close() must not throw on the CDI factory bean
+        factory.close();
+    }
+
+    @Test
+    void closeOnPerCallInstance_releasesArena() {
+        // given
+        G722RtpCodec factory = new G722RtpCodec();
+        factory.probe();
+
+        assumeTrue(factory.isAvailable(), "libspandsp not available on this host — skipping");
+
+        RtpCodec callInstance = factory.forCall();
+
+        // when
+        callInstance.close();
+
+        // then: encoding after close should fail (arena is closed)
+        assertThrows(Exception.class, () -> callInstance.encode(new short[320]));
+    }
+
+    @Test
     void forCallReturnsDifferentInstance() {
         G722RtpCodec factory = new G722RtpCodec();
         factory.probe();

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
@@ -124,6 +124,12 @@ public class CallSessionManager {
         if (!media.localSocket().isClosed()) {
             media.localSocket().close();
         }
+
+        try {
+            media.codec().close();
+        } catch (Exception closeException) {
+            LOGGER.log(System.Logger.Level.DEBUG, "Error closing codec after call", closeException);
+        }
     }
 
     static void sendBye(SipSession session) {


### PR DESCRIPTION
Closes #30

## Changes

### RtpCodec
Extends `AutoCloseable` with a **default no-op `close()`**.
Stateless codecs (PCMA, PCMU) inherit the no-op — no changes needed in those classes.

### G722RtpCodec
- `forCall()`: switched from `Arena.ofAuto()` to `Arena.ofConfined()` so the arena can be closed deterministically.
- Added `close()`: closes `this.callArena` when non-null; no-op on the CDI factory bean.

### CallSessionManager
`closeMedia()` now calls `media.codec().close()` after closing the UDP socket.

### G722RtpCodecTest (2 new tests)
- `closeOnFactoryBean_isNoOp` — verifies `close()` does not throw on the CDI factory bean.
- `closeOnPerCallInstance_releasesArena` — verifies that after `close()`, encoding throws because the confined arena is released.