### PR TITLE
feat: Opus decoder honours RtpCodec.inputSampleRate() for true wideband G.722

### DIFF
--- a/codecs/input/src/main/java/de/bmarwell/proximo/pitido/codecs/input/OggOpusPcmDecoder.java
+++ b/codecs/input/src/main/java/de/bmarwell/proximo/pitido/codecs/input/OggOpusPcmDecoder.java
@@ -30,7 +30,8 @@ import javax.enterprise.context.ApplicationScoped;
 import org.apache.tika.mime.MediaType;
 
 /**
- * Decodes Opus audio stored in an OGG container to 8 kHz mono 16-bit PCM.
+ * Decodes Opus audio stored in an OGG container to mono 16-bit PCM at the sample rate requested
+ * by the caller.
  *
  * <p>OGG pages are read manually (no external OGG library required).
  * Opus packets are decoded via the Foreign Function and Memory (FFM) API,
@@ -38,7 +39,11 @@ import org.apache.tika.mime.MediaType;
  * The system library must be installed: {@code apt install libopus0} on Debian/Ubuntu,
  * or {@code pacman -S opus} on Arch Linux.
  *
- * <p>The decoder is initialised at 8 000 Hz to avoid resampling before RTP/PCMA encoding.
+ * <p>libopus natively supports multiple output rates (8, 12, 16, 24, or 48 kHz);
+ * the rate is chosen at decoder-create time via
+ * {@link #open(InputStream, int)}.
+ * This allows wideband codecs such as G.722 to receive 16 kHz PCM directly,
+ * avoiding the lossy linear-interpolation upsample that would otherwise be required.
  *
  * <p>The first two OGG logical bitstream packets (OpusHead and OpusTags) are silently skipped
  * as required by RFC 7845.
@@ -48,17 +53,11 @@ public class OggOpusPcmDecoder implements PcmDecoder {
 
     private static final System.Logger LOGGER = System.getLogger(OggOpusPcmDecoder.class.getName());
 
-    /** 8 kHz decoder sample rate — matches RTP/PCMA requirement.
-     *
-     * <p>TODO: make this configurable via {@code RtpCodec.inputSampleRate()} so that wideband
-     * codecs (e.g. G.722 at 16 kHz) receive the correct PCM rate from the decode pipeline.
-     * The Opus decoder supports multiple output rates; it would simply need to be re-created
-     * with the target rate instead of 8 000.
+    /**
+     * Maximum Opus frame duration: 120 ms × sample rate / 1000.
+     * Used as a multiplier when computing the per-call buffer size in {@link #open(InputStream, int)}.
      */
-    private static final int SAMPLE_RATE = 8_000;
-
-    /** Maximum decoded samples for one Opus frame (120 ms × 8 000 Hz). */
-    private static final int MAX_FRAME_SAMPLES = 960;
+    private static final int MAX_FRAME_DURATION_MS = 120;
 
     // -------------------------------------------------------------------------
     // FFM binding to libopus
@@ -146,26 +145,34 @@ public class OggOpusPcmDecoder implements PcmDecoder {
 
     @Override
     public PcmStream open(InputStream in) throws IOException {
+        return open(in, 8_000);
+    }
+
+    @Override
+    public PcmStream open(InputStream in, int targetSampleRate) throws IOException {
         if (this.loadError != null) {
             throw this.loadError;
         }
 
         try (Arena callArena = Arena.ofConfined()) {
             MemorySegment errSeg = callArena.allocate(ValueLayout.JAVA_INT);
-            MemorySegment decoder = invokeCreate(errSeg);
+            MemorySegment decoder = invokeCreate(errSeg, targetSampleRate);
             int error = errSeg.get(ValueLayout.JAVA_INT, 0L);
 
             if (decoder == null || decoder.address() == 0L || error != 0) {
                 throw new IOException("opus_decoder_create failed with error " + error);
             }
 
-            return new OggOpusPcmStream(in, this.opusDecode, this.opusDecoderDestroy, decoder);
+            int maxFrameSamples = MAX_FRAME_DURATION_MS * targetSampleRate / 1_000;
+
+            return new OggOpusPcmStream(
+                    in, this.opusDecode, this.opusDecoderDestroy, decoder, targetSampleRate, maxFrameSamples);
         }
     }
 
-    private MemorySegment invokeCreate(MemorySegment errSeg) throws IOException {
+    private MemorySegment invokeCreate(MemorySegment errSeg, int sampleRate) throws IOException {
         try {
-            return (MemorySegment) this.opusDecoderCreate.invoke(SAMPLE_RATE, 1, errSeg);
+            return (MemorySegment) this.opusDecoderCreate.invoke(sampleRate, 1, errSeg);
         } catch (RuntimeException runtimeException) {
             throw runtimeException;
         } catch (Throwable throwable) {
@@ -189,6 +196,9 @@ public class OggOpusPcmDecoder implements PcmDecoder {
          */
         private final MemorySegment decoder;
 
+        private final int streamSampleRate;
+        private final int maxFrameSamples;
+
         /** Packet queue: OGG packets waiting to be decoded. */
         private final Deque<byte[]> packetQueue = new ArrayDeque<>();
 
@@ -207,14 +217,26 @@ public class OggOpusPcmDecoder implements PcmDecoder {
         private boolean endOfStream = false;
 
         OggOpusPcmStream(
-                InputStream in, MethodHandle opusDecode, MethodHandle opusDecoderDestroy, MemorySegment decoder)
+                InputStream in,
+                MethodHandle opusDecode,
+                MethodHandle opusDecoderDestroy,
+                MemorySegment decoder,
+                int sampleRate,
+                int maxFrameSamples)
                 throws IOException {
             this.in = in;
             this.opusDecode = opusDecode;
             this.opusDecoderDestroy = opusDecoderDestroy;
             this.decoder = decoder;
+            this.streamSampleRate = sampleRate;
+            this.maxFrameSamples = maxFrameSamples;
             readNextPage();
             skipHeaderPackets();
+        }
+
+        @Override
+        public int sampleRate() {
+            return this.streamSampleRate;
         }
 
         @Override
@@ -250,7 +272,7 @@ public class OggOpusPcmDecoder implements PcmDecoder {
 
             try (Arena callArena = Arena.ofConfined()) {
                 MemorySegment inputSeg = callArena.allocateFrom(ValueLayout.JAVA_BYTE, packet);
-                MemorySegment pcmSeg = callArena.allocate(ValueLayout.JAVA_SHORT, MAX_FRAME_SAMPLES);
+                MemorySegment pcmSeg = callArena.allocate(ValueLayout.JAVA_SHORT, this.maxFrameSamples);
 
                 int samples = invokeDecode(inputSeg, packet.length, pcmSeg);
 
@@ -273,7 +295,8 @@ public class OggOpusPcmDecoder implements PcmDecoder {
 
         private int invokeDecode(MemorySegment inputSeg, int packetLength, MemorySegment pcmSeg) throws IOException {
             try {
-                return (int) this.opusDecode.invoke(this.decoder, inputSeg, packetLength, pcmSeg, MAX_FRAME_SAMPLES, 0);
+                return (int)
+                        this.opusDecode.invoke(this.decoder, inputSeg, packetLength, pcmSeg, this.maxFrameSamples, 0);
             } catch (RuntimeException runtimeException) {
                 throw runtimeException;
             } catch (Throwable throwable) {

--- a/codecs/input/src/main/java/de/bmarwell/proximo/pitido/codecs/input/PcmDecoder.java
+++ b/codecs/input/src/main/java/de/bmarwell/proximo/pitido/codecs/input/PcmDecoder.java
@@ -17,7 +17,7 @@ import java.io.InputStream;
 import org.apache.tika.mime.MediaType;
 
 /**
- * Opens a compressed audio stream and returns a {@link PcmStream} for reading decoded 8 kHz mono
+ * Opens a compressed audio stream and returns a {@link PcmStream} for reading decoded mono
  * 16-bit PCM samples.
  *
  * <p>Each implementation handles exactly one container/codec combination:
@@ -48,11 +48,33 @@ public interface PcmDecoder {
     boolean supports(String resourcePath, MediaType mimeType);
 
     /**
-     * Opens the given stream and prepares it for PCM sample decoding.
+     * Opens the given stream and prepares it for PCM sample decoding at the default 8 kHz rate.
+     *
+     * <p>Equivalent to {@code open(in, 8_000)}.
      *
      * @param in the raw audio data; ownership is transferred to the returned {@link PcmStream}
      * @return a {@link PcmStream} positioned at the first audio sample
      * @throws IOException if the stream cannot be read or is in an unexpected format
      */
     PcmStream open(InputStream in) throws IOException;
+
+    /**
+     * Opens the given stream and prepares it for PCM sample decoding at the requested sample rate.
+     *
+     * <p>Decoders that support multi-rate output (e.g. {@link OggOpusPcmDecoder} via libopus)
+     * will honour {@code targetSampleRate}.
+     * Decoders that do not support multi-rate output (e.g. {@link WavPcmDecoder}) ignore
+     * {@code targetSampleRate} and always return 8 kHz samples; the caller must detect this via
+     * {@link PcmStream#sampleRate()} and upsample if necessary.
+     *
+     * @param in               the raw audio data; ownership is transferred to the returned stream
+     * @param targetSampleRate the desired output sample rate in Hz, e.g. {@code 8_000} or
+     *                         {@code 16_000}
+     * @return a {@link PcmStream} positioned at the first audio sample;
+     *         {@link PcmStream#sampleRate()} reflects the actual rate chosen by the decoder
+     * @throws IOException if the stream cannot be read or is in an unexpected format
+     */
+    default PcmStream open(InputStream in, int targetSampleRate) throws IOException {
+        return open(in);
+    }
 }

--- a/codecs/input/src/main/java/de/bmarwell/proximo/pitido/codecs/input/PcmStream.java
+++ b/codecs/input/src/main/java/de/bmarwell/proximo/pitido/codecs/input/PcmStream.java
@@ -16,13 +16,28 @@ import java.io.Closeable;
 import java.io.IOException;
 
 /**
- * A stream of decoded 8 kHz mono 16-bit PCM audio samples.
+ * A stream of decoded mono 16-bit PCM audio samples.
  *
- * <p>Callers should read in chunks of 160 samples (20 ms at 8 kHz) to match one RTP packet.
- * The last chunk of a file may be partially filled; the caller must zero-pad it to 160 samples
+ * <p>The actual sample rate is reported by {@link #sampleRate()}.
+ * The caller should read in chunks of {@code sampleRate() / 50} samples (20 ms per RTP packet).
+ * The last chunk of a file may be partially filled; the caller must zero-pad it to a full frame
  * before encoding.
  */
 public interface PcmStream extends Closeable {
+
+    /**
+     * Returns the PCM sample rate in Hz of this stream.
+     *
+     * <p>The default is 8 000 Hz, which suits G.711 A-law (PCMA) and G.711 μ-law (PCMU).
+     * Decoders that support multiple output rates (e.g. {@link OggOpusPcmDecoder}) may return
+     * a higher rate when the caller requests one via
+     * {@link PcmDecoder#open(java.io.InputStream, int)}.
+     *
+     * @return sample rate in Hz, e.g. {@code 8_000} or {@code 16_000}
+     */
+    default int sampleRate() {
+        return 8_000;
+    }
 
     /**
      * Reads up to {@code len} decoded PCM samples into {@code buf} starting at {@code off}.

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpAudioPlayer.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpAudioPlayer.java
@@ -52,7 +52,6 @@ import java.util.Random;
 public class RtpAudioPlayer implements AudioPlayer {
 
     private static final System.Logger LOGGER = System.getLogger(RtpAudioPlayer.class.getName());
-    private static final int DECODE_PIPELINE_SAMPLE_RATE = 8_000;
     private static final int RTP_PACKETS_PER_SECOND = 50;
 
     private final DatagramSocket socket;
@@ -126,6 +125,11 @@ public class RtpAudioPlayer implements AudioPlayer {
      * {@link RtpCodec#inputSampleRate()} Hz, encodes each 20 ms frame via the negotiated codec,
      * and sends it as an RTP packet.
      *
+     * <p>Decoders that support multi-rate output (e.g. {@link de.bmarwell.proximo.pitido.codecs.input.OggOpusPcmDecoder})
+     * will produce samples at exactly {@link RtpCodec#inputSampleRate()}, avoiding any upsampling.
+     * Decoders that do not (e.g. deprecated WAV) fall back to 8 kHz output; the pipeline then
+     * upsamples to match the codec's expectation.
+     *
      * <p>Playback stops immediately when the thread is interrupted.
      *
      * @param resourcePath classpath path of the audio file (e.g. {@code /audio/de/012.opus})
@@ -138,12 +142,12 @@ public class RtpAudioPlayer implements AudioPlayer {
         advanceTimestampForSilence();
 
         try (InputStream rawStream = openResource(resourcePath);
-                PcmStream pcm = this.pcmDecoderFactory.forPath(resourcePath).open(rawStream)) {
-            int decoderSamplesPerPacket = DECODE_PIPELINE_SAMPLE_RATE / RTP_PACKETS_PER_SECOND;
-            int codecInputRate = this.codec.inputSampleRate();
+                PcmStream pcm =
+                        this.pcmDecoderFactory.forPath(resourcePath).open(rawStream, this.codec.inputSampleRate())) {
+            int decoderSamplesPerPacket = pcm.sampleRate() / RTP_PACKETS_PER_SECOND;
             short[] decoderFrameBuf = new short[decoderSamplesPerPacket];
             short[] codecFrameBuf = new short[this.codec.samplesPerFrame()];
-            validateFrameSizing(codecInputRate, decoderSamplesPerPacket, codecFrameBuf.length);
+            validateFrameSizing(decoderSamplesPerPacket, codecFrameBuf.length);
 
             while (true) {
                 if (Thread.currentThread().isInterrupted()) {
@@ -161,7 +165,7 @@ public class RtpAudioPlayer implements AudioPlayer {
                     Arrays.fill(decoderFrameBuf, read, decoderSamplesPerPacket, (short) 0);
                 }
 
-                adaptPcmFrameForCodec(decoderFrameBuf, codecFrameBuf, codecInputRate);
+                adaptPcmFrameForCodec(decoderFrameBuf, codecFrameBuf);
                 sendRtpPacket(this.codec.encode(codecFrameBuf));
                 this.lastPacketSentAt = Instant.now();
                 Thread.sleep(20);
@@ -226,32 +230,22 @@ public class RtpAudioPlayer implements AudioPlayer {
         return stream;
     }
 
-    private static void validateFrameSizing(int codecInputRate, int decoderSamplesPerPacket, int codecSamplesPerPacket)
-            throws IOException {
-        if (codecInputRate == DECODE_PIPELINE_SAMPLE_RATE) {
-            if (codecSamplesPerPacket != decoderSamplesPerPacket) {
-                throw new IOException("Codec frame size mismatch for 8 kHz pipeline: expected "
-                        + decoderSamplesPerPacket + " samples, got: " + codecSamplesPerPacket);
-            }
-
+    private static void validateFrameSizing(int decoderSamplesPerPacket, int codecSamplesPerPacket) throws IOException {
+        if (decoderSamplesPerPacket == codecSamplesPerPacket) {
             return;
         }
 
-        if (codecInputRate == DECODE_PIPELINE_SAMPLE_RATE * 2) {
-            if (codecSamplesPerPacket != decoderSamplesPerPacket * 2) {
-                throw new IOException("Codec frame size mismatch for 16 kHz pipeline: expected "
-                        + (decoderSamplesPerPacket * 2) + " samples, got: " + codecSamplesPerPacket);
-            }
-
+        if (codecSamplesPerPacket == decoderSamplesPerPacket * 2) {
+            // Decoder is at 8 kHz (e.g. deprecated WAV), codec needs 16 kHz — will upsample.
             return;
         }
 
-        throw new IOException("Unsupported codec input sample rate: " + codecInputRate
-                + " Hz (decoder pipeline currently provides only " + DECODE_PIPELINE_SAMPLE_RATE + " Hz)");
+        throw new IOException("Codec frame size mismatch: decoder provides " + decoderSamplesPerPacket
+                + " samples but codec expects " + codecSamplesPerPacket);
     }
 
-    private static void adaptPcmFrameForCodec(short[] decoderFrameBuf, short[] codecFrameBuf, int codecInputRate) {
-        if (codecInputRate == DECODE_PIPELINE_SAMPLE_RATE) {
+    private static void adaptPcmFrameForCodec(short[] decoderFrameBuf, short[] codecFrameBuf) {
+        if (decoderFrameBuf.length == codecFrameBuf.length) {
             System.arraycopy(decoderFrameBuf, 0, codecFrameBuf, 0, decoderFrameBuf.length);
             return;
         }


### PR DESCRIPTION
Closes #31

## Problem

`OggOpusPcmDecoder` was hardcoded to 8 000 Hz.
For G.722 calls, `RtpAudioPlayer` upsampled 8→16 kHz via **linear interpolation**, which introduces high-frequency artefacts and wastes decode bandwidth.
libopus natively supports output at 8, 12, 16, 24, or 48 kHz with no quality loss.

## Solution

### `PcmStream`
New `default int sampleRate()` method (returns 8 000 — backward-compatible with WAV and FLAC decoders).

### `PcmDecoder`
New `default open(InputStream, int targetSampleRate)` that delegates to `open(in)` for decoders that do not support multi-rate output.

### `OggOpusPcmDecoder`
- `open(in)` delegates to `open(in, 8_000)`.
- New `open(in, targetSampleRate)`: creates the libopus decoder at the requested rate; `maxFrameSamples = 120 ms × rate / 1 000`.
- `OggOpusPcmStream` stores and exposes the actual rate via `sampleRate()`.

### `RtpAudioPlayer`
- `playBlocking` calls `decoder.open(rawStream, codec.inputSampleRate())` — G.722 calls now receive 16 kHz PCM natively.
- `decoderSamplesPerPacket` is derived from `pcm.sampleRate()` (the removed `DECODE_PIPELINE_SAMPLE_RATE` constant is gone).
- `adaptPcmFrameForCodec` compares buffer lengths; upsampling is kept as a fallback for the deprecated WAV + G.722 edge case.