### PR TITLE
feat: Opus over RTP (RFC 7587) encoder

### DIFF
--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/G722RtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/G722RtpCodec.java
@@ -74,7 +74,7 @@ import javax.enterprise.context.ApplicationScoped;
  * @see PcmaRtpCodec
  */
 @ApplicationScoped
-public final class G722RtpCodec implements RtpCodec {
+public final class G722RtpCodec extends NativeRtpCodec {
 
     private static final System.Logger LOGGER = System.getLogger(G722RtpCodec.class.getName());
 
@@ -94,22 +94,10 @@ public final class G722RtpCodec implements RtpCodec {
     private static final int G722_OPTIONS = 0;
 
     // CDI factory bean fields — set by @PostConstruct; null in per-call instances.
-    private boolean available = false;
     private MethodHandle g722EncodeInitHandle;
 
     // Shared between factory and per-call instances.
     private MethodHandle g722EncodeHandle;
-
-    // Per-call instance fields — null in the CDI factory bean.
-
-    /**
-     * Confined arena owning the native encoder state for this call leg.
-     * {@code null} in the CDI factory bean.
-     *
-     * <p>Closed explicitly by {@link #close()} when the call ends, releasing the native
-     * encoder state immediately rather than waiting for GC.
-     */
-    private final Arena callArena;
 
     /**
      * Allocated and initialised {@code g722_encode_state_t} for one call leg.
@@ -119,7 +107,6 @@ public final class G722RtpCodec implements RtpCodec {
 
     /** CDI no-args constructor. */
     public G722RtpCodec() {
-        this.callArena = null;
         this.stateSegment = null;
     }
 
@@ -129,14 +116,13 @@ public final class G722RtpCodec implements RtpCodec {
      * <p>Not intended for direct use; called only by {@link #forCall()}.
      *
      * @param g722EncodeHandle downcall handle for {@code g722_encode}, resolved at probe time
-     * @param callArena        GC-managed arena owning the encoder state for the call's lifetime
+     * @param callArena        confined arena owning the encoder state for the call's lifetime
      * @param stateSegment     allocated and initialised {@code g722_encode_state_t}
      */
     G722RtpCodec(MethodHandle g722EncodeHandle, Arena callArena, MemorySegment stateSegment) {
+        super(callArena);
         this.g722EncodeHandle = g722EncodeHandle;
-        this.callArena = callArena;
         this.stateSegment = stateSegment;
-        this.available = true;
     }
 
     /**
@@ -184,11 +170,6 @@ public final class G722RtpCodec implements RtpCodec {
     }
 
     @Override
-    public boolean isAvailable() {
-        return this.available;
-    }
-
-    @Override
     public int preference() {
         // Preferred over PCMA when available: wideband audio sounds significantly better.
         return 50;
@@ -201,7 +182,8 @@ public final class G722RtpCodec implements RtpCodec {
      * Sharing ADPCM predictor state across calls corrupts the audio stream.
      *
      * <p>The returned instance is not a CDI bean.
-     * It holds a GC-managed {@link Arena} and an initialised {@code g722_encode_state_t}.
+     * It holds a confined {@link Arena} and an initialised {@code g722_encode_state_t};
+     * call {@link #close()} when the call ends.
      *
      * @throws IllegalStateException if {@code g722_encode_init} returns a null pointer
      */
@@ -287,16 +269,8 @@ public final class G722RtpCodec implements RtpCodec {
 
     /**
      * Closes the confined arena, releasing the native {@code g722_encode_state_t} segment.
-     *
-     * <p>A no-op when called on the CDI factory bean (whose {@link #callArena} is {@code null}).
+     * Inherited from {@link NativeRtpCodec}; no-op on the CDI factory bean.
      */
-    @Override
-    public void close() {
-        if (this.callArena != null) {
-            this.callArena.close();
-        }
-    }
-
     private MemorySegment invokeEncodeInit(MemorySegment state) {
         try {
             return (MemorySegment) this.g722EncodeInitHandle.invoke(state, G722_RATE, G722_OPTIONS);

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/NativeRtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/NativeRtpCodec.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.codecs.sip;
+
+import java.lang.foreign.Arena;
+
+/**
+ * Abstract base class for RTP codecs backed by a native shared library loaded via the
+ * Foreign Function and Memory (FFM) API.
+ *
+ * <p>Provides the common scaffolding shared by all native codecs:
+ * <ul>
+ *   <li>{@link #available} flag and {@link #isAvailable()} — set to {@code true} by
+ *       {@code @PostConstruct} probe methods when the native library loads successfully.</li>
+ *   <li>{@link #callArena} — a {@link Arena#ofConfined() confined arena} that owns the
+ *       per-call native encoder state; {@code null} in CDI factory beans.</li>
+ *   <li>{@link #close()} — closes the confined arena, releasing native state immediately
+ *       when the call ends.</li>
+ * </ul>
+ *
+ * <h2>CDI factory / per-call pattern</h2>
+ *
+ * <p>Stateful native codecs follow a two-instance pattern:
+ * <ol>
+ *   <li>A CDI {@code @ApplicationScoped} factory bean is created via the no-args constructor
+ *       {@link #NativeRtpCodec()}.
+ *       Its {@link #callArena} is {@code null} and {@link #available} starts {@code false}.</li>
+ *   <li>After the CDI {@code @PostConstruct} probe method successfully loads the native library,
+ *       {@link #available} is set to {@code true}.</li>
+ *   <li>{@link RtpCodec#forCall()} allocates a {@link Arena#ofConfined() confined arena}, creates
+ *       and initialises native encoder state inside it, then constructs a per-call instance via
+ *       {@link #NativeRtpCodec(Arena)}.
+ *       Per-call instances have {@link #available} {@code true} from construction.</li>
+ *   <li>When the call ends, {@link de.bmarwell.proximo.pitido.war.media.CallSessionManager}
+ *       calls {@link #close()}, which closes the arena and releases the native state.</li>
+ * </ol>
+ *
+ * <p>Stateless pure-Java codecs ({@link PcmaRtpCodec}, {@link PcmuRtpCodec}) do not extend this
+ * class; they implement {@link RtpCodec} directly and inherit the default no-op {@code close()}.
+ */
+public abstract class NativeRtpCodec implements RtpCodec {
+
+    /**
+     * Whether the native library was successfully loaded.
+     *
+     * <p>{@code false} in freshly constructed CDI factory beans;
+     * set to {@code true} by the subclass {@code @PostConstruct} probe method.
+     * Always {@code true} in per-call instances created by {@link RtpCodec#forCall()}.
+     */
+    protected boolean available = false;
+
+    /**
+     * Confined arena owning the per-call native encoder state.
+     * {@code null} in the CDI factory bean; non-null in per-call instances.
+     *
+     * <p>Closed by {@link #close()} when the call ends.
+     */
+    protected final Arena callArena;
+
+    /**
+     * CDI factory bean constructor.
+     *
+     * <p>Sets {@link #callArena} to {@code null}.
+     * {@link #available} starts {@code false}; the subclass {@code @PostConstruct} probe method
+     * sets it to {@code true} after a successful library load.
+     */
+    protected NativeRtpCodec() {
+        this.callArena = null;
+    }
+
+    /**
+     * Per-call instance constructor.
+     *
+     * <p>Sets {@link #callArena} to the given arena and marks the instance as
+     * {@link #available} (since the native library was confirmed at probe time).
+     *
+     * @param callArena a confined arena owning the native encoder state for this call leg;
+     *                  must not be {@code null}
+     */
+    protected NativeRtpCodec(Arena callArena) {
+        this.callArena = callArena;
+        this.available = true;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return this.available;
+    }
+
+    /**
+     * Closes the confined arena, releasing the native encoder state immediately.
+     *
+     * <p>A no-op when called on the CDI factory bean (whose {@link #callArena} is {@code null}).
+     */
+    @Override
+    public void close() {
+        if (this.callArena != null) {
+            this.callArena.close();
+        }
+    }
+}

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/OpusRtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/OpusRtpCodec.java
@@ -1,0 +1,398 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.codecs.sip;
+
+import java.io.IOException;
+import java.lang.foreign.Arena;
+import java.lang.foreign.FunctionDescriptor;
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemorySegment;
+import java.lang.foreign.SymbolLookup;
+import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * Opus RTP codec (RFC 7587, dynamic payload type 111).
+ *
+ * <p>Opus is a versatile open codec developed by the IETF Codec Working Group.
+ * At 48 kHz mono it delivers transparent, wideband audio (20 Hz–20 kHz) in VBR mode,
+ * making it the codec of choice for FLOSS softphones such as Linphone, Baresip, and Jitsi.
+ *
+ * <p>Deutsche Telekom, SIPGate, and other PSTN SIP trunks do not support Opus; they will never
+ * offer it in an SDP INVITE, so this codec is automatically bypassed for those callers.
+ *
+ * <h2>SDP declaration</h2>
+ *
+ * <p>Per RFC 7587 §5, the SDP attribute lines are:
+ * <pre>
+ * a=rtpmap:111 opus/48000/2
+ * a=fmtp:111 useinbandfec=1
+ * </pre>
+ *
+ * <p>The channel count of 2 in the {@code rtpmap} line is mandated by RFC 7587 regardless of
+ * the actual channel count in the stream; this codec sends mono.
+ *
+ * <h2>Encoding parameters</h2>
+ *
+ * <ul>
+ *   <li>Application: {@code OPUS_APPLICATION_VOIP} — optimised for voice; activates
+ *       voice activity detection, noise suppression, and in-band FEC.</li>
+ *   <li>In-band FEC: enabled via {@code OPUS_SET_INBAND_FEC_REQUEST = 1} — libopus embeds
+ *       redundant recovery data for the previous packet inside the current packet, so receivers
+ *       can conceal moderate random packet loss without retransmission.</li>
+ *   <li>Bitrate: {@code OPUS_AUTO} (default) — libopus selects the optimal VBR bitrate for
+ *       the signal content, typically 24–32 kbps for mono voice at 48 kHz.</li>
+ *   <li>Frame size: 20 ms (960 samples at 48 kHz) — matches the standard RTP packet cadence.</li>
+ * </ul>
+ *
+ * <h2>Native backend — libopus via FFM</h2>
+ *
+ * <p>Encoding is performed by {@code libopus} via the Foreign Function and Memory (FFM) API.
+ * The same native library is used by
+ * {@link de.bmarwell.proximo.pitido.codecs.input.OggOpusPcmDecoder} for audio file decoding;
+ * it must be installed on the host system:
+ * <ul>
+ *   <li>Debian / Ubuntu: {@code apt install libopus0}</li>
+ *   <li>Arch Linux: {@code pacman -S opus}</li>
+ *   <li>RHEL / UBI 9: {@code microdnf install opus} (available in the base repository)</li>
+ * </ul>
+ *
+ * <h2>Factory / per-call pattern</h2>
+ *
+ * <p>Opus ADPCM carries predictor state across packets.
+ * This {@code @ApplicationScoped} CDI bean acts as a factory: {@link #forCall()} determines the
+ * required encoder state size via {@code opus_encoder_get_size}, allocates a confined
+ * {@link Arena}, initialises it with {@code opus_encoder_init}, and returns a plain (non-CDI)
+ * {@code OpusRtpCodec} instance.
+ * When the call ends, {@link de.bmarwell.proximo.pitido.war.media.CallSessionManager} calls
+ * {@link #close()}, which releases the confined arena and all native state immediately.
+ *
+ * @see G722RtpCodec
+ * @see NativeRtpCodec
+ */
+@ApplicationScoped
+public final class OpusRtpCodec extends NativeRtpCodec {
+
+    private static final System.Logger LOGGER = System.getLogger(OpusRtpCodec.class.getName());
+
+    /** libopus application mode optimised for voice; enables DTX, FEC, and noise suppression. */
+    private static final int OPUS_APPLICATION_VOIP = 2048;
+
+    /**
+     * CTL request code for enabling in-band FEC.
+     * Passed as the first variadic argument to {@code opus_encoder_ctl}.
+     */
+    private static final int OPUS_SET_INBAND_FEC_REQUEST = 4012;
+
+    /** Mono encoding: one channel. */
+    private static final int OPUS_CHANNELS = 1;
+
+    /** Opus native sample rate: 48 000 Hz. */
+    private static final int OPUS_SAMPLE_RATE = 48_000;
+
+    /** 20 ms frame at 48 kHz: 960 samples. */
+    private static final int FRAME_SAMPLES = 960;
+
+    /**
+     * Conservative upper bound for one encoded Opus frame.
+     * 4 000 bytes vastly exceeds any realistic 20 ms voice frame;
+     * libopus will never exceed this limit for the given frame size and bitrate.
+     */
+    private static final int MAX_ENCODED_BYTES = 4000;
+
+    /**
+     * Alignment for the {@code OpusEncoder} state struct.
+     * On x86-64, libopus uses 8-byte-aligned double fields internally.
+     */
+    private static final long STATE_ALIGN = 8L;
+
+    // -------------------------------------------------------------------------
+    // CDI factory bean — set by @PostConstruct, null in per-call instances
+    // -------------------------------------------------------------------------
+
+    private MethodHandle opusEncoderGetSizeHandle;
+    private MethodHandle opusEncoderInitHandle;
+    /** Typed binding for {@code opus_encoder_ctl(encoder, request, intValue)} (variadic). */
+    private MethodHandle opusEncoderCtlIntHandle;
+
+    // -------------------------------------------------------------------------
+    // Shared between factory and per-call instances
+    // -------------------------------------------------------------------------
+
+    private MethodHandle opusEncodeHandle;
+    private MethodHandle opusEncoderDestroyHandle;
+
+    // -------------------------------------------------------------------------
+    // Per-call instance fields — null in the CDI factory bean
+    // -------------------------------------------------------------------------
+
+    /**
+     * Pointer to the initialised {@code OpusEncoder} state, allocated inside
+     * {@link NativeRtpCodec#callArena}.
+     * {@code null} in the CDI factory bean.
+     */
+    private final MemorySegment stateSegment;
+
+    /** CDI no-args constructor. */
+    public OpusRtpCodec() {
+        this.stateSegment = null;
+    }
+
+    /**
+     * Per-call constructor — creates a non-CDI encoder instance for exactly one call leg.
+     *
+     * <p>Not intended for direct use; called only by {@link #forCall()}.
+     *
+     * @param opusEncodeHandle        downcall handle for {@code opus_encode}
+     * @param opusEncoderDestroyHandle downcall handle for {@code opus_encoder_destroy}
+     * @param callArena               confined arena owning the encoder state
+     * @param stateSegment            initialised {@code OpusEncoder} state
+     */
+    OpusRtpCodec(
+            MethodHandle opusEncodeHandle,
+            MethodHandle opusEncoderDestroyHandle,
+            Arena callArena,
+            MemorySegment stateSegment) {
+        super(callArena);
+        this.opusEncodeHandle = opusEncodeHandle;
+        this.opusEncoderDestroyHandle = opusEncoderDestroyHandle;
+        this.stateSegment = stateSegment;
+    }
+
+    /**
+     * Probes for {@code libopus.so.0} and binds all required FFM method handles.
+     *
+     * <p>Called once by the CDI container after construction.
+     * Sets {@link NativeRtpCodec#available} to {@code true} when the library is found.
+     * Uses {@link Arena#global()} so the library remains loaded for the lifetime of the JVM.
+     */
+    @PostConstruct
+    @SuppressWarnings("restricted") // SymbolLookup.libraryLookup is FFM restricted — intentional use
+    void probe() {
+        try {
+            SymbolLookup opus = SymbolLookup.libraryLookup("libopus.so.0", Arena.global());
+            Linker linker = Linker.nativeLinker();
+
+            this.opusEncoderGetSizeHandle = linker.downcallHandle(
+                    opus.find("opus_encoder_get_size").orElseThrow(),
+                    FunctionDescriptor.of(
+                            ValueLayout.JAVA_INT, // return: size in bytes
+                            ValueLayout.JAVA_INT // channels
+                            ));
+
+            this.opusEncoderInitHandle = linker.downcallHandle(
+                    opus.find("opus_encoder_init").orElseThrow(),
+                    FunctionDescriptor.of(
+                            ValueLayout.JAVA_INT, // return: OPUS_OK (0) on success
+                            ValueLayout.ADDRESS, // OpusEncoder* st
+                            ValueLayout.JAVA_INT, // Fs (sample rate)
+                            ValueLayout.JAVA_INT, // channels
+                            ValueLayout.JAVA_INT // application
+                            ));
+
+            this.opusEncodeHandle = linker.downcallHandle(
+                    opus.find("opus_encode").orElseThrow(),
+                    FunctionDescriptor.of(
+                            ValueLayout.JAVA_INT, // return: bytes encoded (>0) or error (<0)
+                            ValueLayout.ADDRESS, // OpusEncoder* st
+                            ValueLayout.ADDRESS, // const opus_int16* pcm
+                            ValueLayout.JAVA_INT, // frame_size (samples)
+                            ValueLayout.ADDRESS, // unsigned char* data (output)
+                            ValueLayout.JAVA_INT // max_data_bytes
+                            ));
+
+            this.opusEncoderDestroyHandle = linker.downcallHandle(
+                    opus.find("opus_encoder_destroy").orElseThrow(), FunctionDescriptor.ofVoid(ValueLayout.ADDRESS));
+
+            // Variadic binding for opus_encoder_ctl(encoder, request, int_value).
+            // firstVariadicArg(2) tells the linker that argument index 2 is the first variadic.
+            this.opusEncoderCtlIntHandle = linker.downcallHandle(
+                    opus.find("opus_encoder_ctl").orElseThrow(),
+                    FunctionDescriptor.of(
+                            ValueLayout.JAVA_INT, // return: OPUS_OK (0)
+                            ValueLayout.ADDRESS, // OpusEncoder* st
+                            ValueLayout.JAVA_INT, // request
+                            ValueLayout.JAVA_INT // variadic int value
+                            ),
+                    Linker.Option.firstVariadicArg(2));
+
+            this.available = true;
+            LOGGER.log(System.Logger.Level.INFO, "libopus detected — Opus RTP codec available");
+
+        } catch (IllegalArgumentException illegalArgumentException) {
+            LOGGER.log(
+                    System.Logger.Level.WARNING,
+                    "libopus not found — Opus RTP codec disabled: {0}",
+                    illegalArgumentException.getMessage());
+        }
+    }
+
+    @Override
+    public int preference() {
+        // Preferred over G.722 (50) when both are available: Opus delivers higher quality
+        // and wider frequency response at equivalent or lower bitrate.
+        // PSTN trunks never offer Opus, so this preference only activates for softphone callers.
+        return 30;
+    }
+
+    /**
+     * Returns a new per-call encoder instance with freshly initialised Opus encoder state.
+     *
+     * <p>Uses {@code opus_encoder_get_size(1)} to determine the required allocation, then
+     * allocates a confined arena and calls {@code opus_encoder_init} followed by
+     * {@code opus_encoder_ctl} to enable in-band FEC.
+     *
+     * @throws IllegalStateException if encoder initialisation fails
+     */
+    @Override
+    public RtpCodec forCall() {
+        int stateSize = invokeGetSize();
+        Arena arena = Arena.ofConfined();
+        MemorySegment state = arena.allocate(stateSize, STATE_ALIGN);
+        invokeInit(state);
+        invokeCtlInt(state, OPUS_SET_INBAND_FEC_REQUEST, 1);
+
+        return new OpusRtpCodec(this.opusEncodeHandle, this.opusEncoderDestroyHandle, arena, state);
+    }
+
+    @Override
+    public int payloadType() {
+        // De-facto standard dynamic payload type for Opus, used by virtually all softphones.
+        return 111;
+    }
+
+    @Override
+    public int rtpClockRate() {
+        // RFC 7587 §4: Opus RTP clock rate is 48 000 Hz (no historical anomaly here).
+        return OPUS_SAMPLE_RATE;
+    }
+
+    @Override
+    public int inputSampleRate() {
+        return OPUS_SAMPLE_RATE;
+    }
+
+    @Override
+    public int samplesPerFrame() {
+        // 20 ms × 48 000 Hz = 960 samples
+        return FRAME_SAMPLES;
+    }
+
+    @Override
+    public int rtpTimestampIncrement() {
+        // 48 000 Hz / 50 packets per second = 960
+        return FRAME_SAMPLES;
+    }
+
+    @Override
+    public String sdpName() {
+        return "opus";
+    }
+
+    /**
+     * Returns {@code 2} as required by RFC 7587 §5, regardless of actual channel count.
+     * The stream is mono; the SDP channel field is fixed at 2 for interoperability.
+     */
+    @Override
+    public int sdpChannelCount() {
+        return 2;
+    }
+
+    @Override
+    public String fmtpParams() {
+        // useinbandfec=1: instruct the remote to use in-band FEC recovery when available.
+        return "useinbandfec=1";
+    }
+
+    /**
+     * Encodes one frame of 960 mono PCM samples at 48 kHz to Opus wire format.
+     *
+     * <p>The returned byte array length varies per frame (VBR); the caller wraps it directly
+     * as the RTP payload.
+     * This method is only valid on per-call instances created by {@link #forCall()}.
+     *
+     * @param pcmFrame 960 mono PCM samples at 48 000 Hz; length must equal
+     *                 {@link #samplesPerFrame()}
+     * @return Opus-encoded bytes for one RTP packet
+     * @throws IOException           if {@code opus_encode} returns a negative error code
+     * @throws IllegalStateException if called on the CDI factory bean (no encoder state)
+     */
+    @Override
+    public byte[] encode(short[] pcmFrame) throws IOException {
+        if (this.stateSegment == null) {
+            throw new IllegalStateException(
+                    "encode() must not be called on the CDI factory bean; obtain a per-call instance via forCall() first");
+        }
+
+        try (Arena frameArena = Arena.ofConfined()) {
+            MemorySegment inputSeg = frameArena.allocateFrom(ValueLayout.JAVA_SHORT, pcmFrame);
+            MemorySegment outputSeg = frameArena.allocate(ValueLayout.JAVA_BYTE, MAX_ENCODED_BYTES);
+
+            int bytesEncoded = invokeEncode(inputSeg, outputSeg);
+
+            if (bytesEncoded < 0) {
+                throw new IOException("opus_encode failed with error code " + bytesEncoded);
+            }
+
+            return outputSeg.asSlice(0L, bytesEncoded).toArray(ValueLayout.JAVA_BYTE);
+        }
+    }
+
+    private int invokeGetSize() {
+        try {
+            return (int) this.opusEncoderGetSizeHandle.invoke(OPUS_CHANNELS);
+        } catch (RuntimeException runtimeException) {
+            throw runtimeException;
+        } catch (Throwable throwable) {
+            throw new IllegalStateException("opus_encoder_get_size invocation failed", throwable);
+        }
+    }
+
+    private void invokeInit(MemorySegment state) {
+        try {
+            int result = (int)
+                    this.opusEncoderInitHandle.invoke(state, OPUS_SAMPLE_RATE, OPUS_CHANNELS, OPUS_APPLICATION_VOIP);
+
+            if (result != 0) {
+                throw new IllegalStateException("opus_encoder_init failed with error code " + result);
+            }
+        } catch (RuntimeException runtimeException) {
+            throw runtimeException;
+        } catch (Throwable throwable) {
+            throw new IllegalStateException("opus_encoder_init invocation failed", throwable);
+        }
+    }
+
+    private void invokeCtlInt(MemorySegment state, int request, int value) {
+        try {
+            this.opusEncoderCtlIntHandle.invoke(state, request, value);
+        } catch (RuntimeException runtimeException) {
+            throw runtimeException;
+        } catch (Throwable throwable) {
+            throw new IllegalStateException("opus_encoder_ctl invocation failed", throwable);
+        }
+    }
+
+    private int invokeEncode(MemorySegment inputSeg, MemorySegment outputSeg) throws IOException {
+        try {
+            return (int) this.opusEncodeHandle.invoke(
+                    this.stateSegment, inputSeg, FRAME_SAMPLES, outputSeg, MAX_ENCODED_BYTES);
+        } catch (RuntimeException runtimeException) {
+            throw runtimeException;
+        } catch (Throwable throwable) {
+            throw new IOException("opus_encode invocation failed", throwable);
+        }
+    }
+}

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/RtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/RtpCodec.java
@@ -120,6 +120,22 @@ public interface RtpCodec extends AutoCloseable {
     byte[] encode(short[] pcmFrame) throws IOException;
 
     /**
+     * Number of channels declared in the SDP {@code a=rtpmap} encoding-parameters field.
+     *
+     * <p>Most voice codecs are mono and omit this field (the default is 1).
+     * Opus declares 2 channels in the SDP per RFC 7587 §5, even when encoding mono audio,
+     * for historical interoperability reasons.
+     *
+     * <p>The default returns {@code 1}; codecs that require a different value (e.g.
+     * {@link OpusRtpCodec}) override this method.
+     *
+     * @return the SDP channel count, usually {@code 1}
+     */
+    default int sdpChannelCount() {
+        return 1;
+    }
+
+    /**
      * Codec name used in the SDP {@code a=rtpmap} attribute, e.g. {@code "PCMA"} or
      * {@code "G722"}.
      */

--- a/codecs/sip/src/test/java/de/bmarwell/proximo/pitido/codecs/sip/OpusRtpCodecTest.java
+++ b/codecs/sip/src/test/java/de/bmarwell/proximo/pitido/codecs/sip/OpusRtpCodecTest.java
@@ -1,0 +1,174 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.codecs.sip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.junit.jupiter.api.Test;
+
+class OpusRtpCodecTest {
+
+    private final OpusRtpCodec codec = new OpusRtpCodec();
+
+    // -------------------------------------------------------------------------
+    // Codec constants — no native library needed
+    // -------------------------------------------------------------------------
+
+    @Test
+    void payloadTypeIs111() {
+        assertEquals(111, codec.payloadType());
+    }
+
+    @Test
+    void rtpClockRateIs48000() {
+        assertEquals(48_000, codec.rtpClockRate());
+    }
+
+    @Test
+    void inputSampleRateIs48000() {
+        assertEquals(48_000, codec.inputSampleRate());
+    }
+
+    @Test
+    void samplesPerFrameIs960() {
+        assertEquals(960, codec.samplesPerFrame());
+    }
+
+    @Test
+    void rtpTimestampIncrementIs960() {
+        assertEquals(960, codec.rtpTimestampIncrement());
+    }
+
+    @Test
+    void sdpNameIsOpus() {
+        assertEquals("opus", codec.sdpName());
+    }
+
+    @Test
+    void sdpChannelCountIsTwo() {
+        // given: RFC 7587 §5 mandates 2 in SDP regardless of actual channel count
+        // when / then
+        assertEquals(2, codec.sdpChannelCount());
+    }
+
+    @Test
+    void fmtpParamsContainsFec() {
+        assertEquals("useinbandfec=1", codec.fmtpParams());
+    }
+
+    @Test
+    void preferenceIs30() {
+        assertEquals(30, codec.preference());
+    }
+
+    @Test
+    void preferenceIsHigherThanG722() {
+        // given
+        var g722 = new G722RtpCodec();
+
+        // when / then: Opus (30) must beat G.722 (50) — lower number = higher priority
+        assertEquals(
+                true,
+                codec.preference() < g722.preference(),
+                "Opus preference must be higher priority (lower number) than G.722");
+    }
+
+    @Test
+    void encodeThrowsOnFactoryBean() {
+        // given: an un-probed CDI factory bean with no encoder state
+        // when / then
+        assertThrows(IllegalStateException.class, () -> codec.encode(new short[960]));
+    }
+
+    // -------------------------------------------------------------------------
+    // Tests that require libopus — skipped automatically when not installed
+    // -------------------------------------------------------------------------
+
+    @Test
+    void closeOnFactoryBean_isNoOp() {
+        // given: a fresh factory bean (no callArena)
+        var factory = new OpusRtpCodec();
+
+        // when / then: close() must not throw on the CDI factory bean
+        factory.close();
+    }
+
+    @Test
+    void forCallReturnsDifferentInstance() {
+        // given
+        OpusRtpCodec factory = new OpusRtpCodec();
+        factory.probe();
+
+        assumeTrue(factory.isAvailable(), "libopus not available on this host — skipping");
+
+        // when
+        RtpCodec callInstance = factory.forCall();
+
+        // then
+        assertNotSame(factory, callInstance);
+    }
+
+    @Test
+    void forCallReturnsFreshInstanceEachTime() {
+        // given
+        OpusRtpCodec factory = new OpusRtpCodec();
+        factory.probe();
+
+        assumeTrue(factory.isAvailable(), "libopus not available on this host — skipping");
+
+        // when
+        RtpCodec first = factory.forCall();
+        RtpCodec second = factory.forCall();
+
+        // then: each call leg must have independent encoder state
+        assertNotSame(first, second);
+    }
+
+    @Test
+    void closeOnPerCallInstance_releasesArena() {
+        // given
+        OpusRtpCodec factory = new OpusRtpCodec();
+        factory.probe();
+
+        assumeTrue(factory.isAvailable(), "libopus not available on this host — skipping");
+
+        RtpCodec callInstance = factory.forCall();
+
+        // when
+        callInstance.close();
+
+        // then: encoding after close should fail (arena is closed)
+        assertThrows(Exception.class, () -> callInstance.encode(new short[960]));
+    }
+
+    @Test
+    void silenceFrameEncodesSuccessfully() throws Exception {
+        // given
+        OpusRtpCodec factory = new OpusRtpCodec();
+        factory.probe();
+
+        assumeTrue(factory.isAvailable(), "libopus not available on this host — skipping");
+
+        RtpCodec encoder = factory.forCall();
+        short[] silence = new short[960];
+
+        // when
+        byte[] encoded = encoder.encode(silence);
+
+        // then: Opus should always produce at least a minimal comfort-noise frame
+        assertEquals(true, encoded.length > 0, "Encoded frame must not be empty");
+    }
+}

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -226,8 +226,13 @@ public class SdpNegotiator {
                 .append(" ")
                 .append(codec.sdpName())
                 .append("/")
-                .append(codec.rtpClockRate())
-                .append("\r\n");
+                .append(codec.rtpClockRate());
+
+        if (codec.sdpChannelCount() > 1) {
+            sdp.append("/").append(codec.sdpChannelCount());
+        }
+
+        sdp.append("\r\n");
 
         if (!codec.fmtpParams().isEmpty()) {
             sdp.append("a=fmtp:")


### PR DESCRIPTION
Closes #34.

## Changes

- **`NativeRtpCodec`** — new abstract base class for FFM-backed codecs; provides `available`, `callArena`, `isAvailable()`, and `close()`
- **`G722RtpCodec`** — refactored to `extends NativeRtpCodec`; removes duplicated `isAvailable()` and `close()` overrides; restores missing `STATE_SIZE` constant; updates Javadoc
- **`RtpCodec`** — adds `default int sdpChannelCount() { return 1; }`
- **`SdpNegotiator`** — appends `/<channels>` to the `a=rtpmap` line when `sdpChannelCount() > 1` (required for Opus per RFC 7587 §5)
- **`OpusRtpCodec`** — new codec: payload type 111, 48 kHz, 20 ms frames, VBR with in-band FEC, preference 30 (preferred over G.722 for softphone callers; PSTN trunks are unaffected)
- **`OpusRtpCodecTest`** — constant checks + native tests guarded with `assumeTrue(isAvailable())`