### PR TITLE
fix: handle hold re-INVITE gracefully (#33)

### DIFF
--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
@@ -84,6 +84,9 @@ public class CallAcceptor {
     @Inject
     AnnouncementLoop announcementLoop;
 
+    @Inject
+    HoldHandler holdHandler;
+
     @Resource
     ManagedExecutorService managedExecutorService;
 
@@ -96,6 +99,14 @@ public class CallAcceptor {
      */
     public void accept(SipServletRequest req) throws IOException {
         String callId = req.getSession().getId();
+
+        if (this.callSessionManager.get(callId) != null) {
+            // Re-INVITE on an established session: handle hold/unhold.
+            this.holdHandler.handle(req);
+
+            return;
+        }
+
         LOGGER.log(
                 System.Logger.Level.DEBUG,
                 "{0}Incoming call from [{1}]",

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/HoldHandler.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/HoldHandler.java
@@ -1,0 +1,152 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.war.listener;
+
+import de.bmarwell.proximo.pitido.war.media.CallMedia;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import javax.enterprise.context.ApplicationScoped;
+import javax.inject.Inject;
+import javax.servlet.sip.SipServletRequest;
+import javax.servlet.sip.SipServletResponse;
+
+/**
+ * Handles in-dialog re-INVITEs used for call hold and unhold.
+ *
+ * <p>When a caller puts a call on hold, their phone sends a re-INVITE containing
+ * {@code a=sendonly} or {@code a=inactive} in the SDP offer.
+ * The current implementation would treat this as a new INVITE, causing undefined behaviour.
+ * This bean detects the re-INVITE, pauses or resumes RTP, and responds with {@code 200 OK}.
+ *
+ * <h2>Hold detection</h2>
+ *
+ * <p>The SDP direction attribute is inspected:
+ * <ul>
+ *   <li>{@code a=sendonly} — caller is sending hold; we stop sending RTP and reply
+ *       {@code a=recvonly}.</li>
+ *   <li>{@code a=inactive} — caller is fully inactive; we stop sending RTP and reply
+ *       {@code a=inactive}.</li>
+ *   <li>{@code a=recvonly} or {@code a=sendrecv} (or absent) — caller is resuming;
+ *       we resume RTP and reply {@code a=sendrecv}.</li>
+ * </ul>
+ *
+ * <h2>RTP behaviour during hold</h2>
+ *
+ * <p>The audio sender thread continues running but skips sending RTP packets and pauses PCM
+ * file consumption (see {@link de.bmarwell.proximo.pitido.war.media.RtpAudioPlayer}).
+ * The RTP timestamp is still advanced per 20 ms tick so the timeline is correct on resume.
+ * When the caller un-holds, the announcement resumes from where it paused.
+ *
+ * <h2>Session expiry</h2>
+ *
+ * <p>For a speaking-clock call (5–15 seconds), the announcement will typically have finished
+ * before the caller un-holds.
+ * The RTP sender thread will have exited naturally; the SIP session is left open until the
+ * caller sends BYE.
+ */
+@ApplicationScoped
+public class HoldHandler {
+
+    private static final System.Logger LOGGER = System.getLogger(HoldHandler.class.getName());
+
+    @Inject
+    CallSessionManager callSessionManager;
+
+    /**
+     * Processes a re-INVITE, pausing or resuming RTP based on the SDP direction.
+     * Responds with {@code 200 OK} and an updated SDP direction.
+     *
+     * @param req the re-INVITE request; must belong to an already-established session
+     * @throws IOException if sending the SIP response fails
+     */
+    public void handle(SipServletRequest req) throws IOException {
+        String sessionId = req.getSession().getId();
+        CallState callState = this.callSessionManager.get(sessionId);
+
+        if (callState == null) {
+            LOGGER.log(
+                    System.Logger.Level.WARNING,
+                    "{0}Re-INVITE received but no active call state found — responding 481",
+                    SipCallHeaders.callPrefix(sessionId));
+            req.createResponse(SipServletResponse.SC_CALL_LEG_DONE).send();
+
+            return;
+        }
+
+        String sdpOffer = readSdpBody(req);
+        boolean callerIsHolding = isHoldOffer(sdpOffer);
+        boolean inactive = sdpOffer.lines().anyMatch(line -> line.strip().equals("a=inactive"));
+        CallMedia media = callState.media();
+
+        if (callerIsHolding) {
+            media.hold();
+            String direction = inactive ? "inactive" : "recvonly";
+            LOGGER.log(
+                    System.Logger.Level.INFO,
+                    "{0}Call put on hold (SDP direction: {1})",
+                    SipCallHeaders.callPrefix(sessionId),
+                    direction);
+            sendOkWithDirection(req, media, direction);
+        } else {
+            media.unhold();
+            LOGGER.log(System.Logger.Level.INFO, "{0}Call resumed from hold", SipCallHeaders.callPrefix(sessionId));
+            sendOkWithDirection(req, media, "sendrecv");
+        }
+    }
+
+    /**
+     * Returns {@code true} when the SDP offer indicates the caller is placing the call on hold.
+     * Checks for {@code a=sendonly} or {@code a=inactive} in the media section.
+     */
+    static boolean isHoldOffer(String sdp) {
+        return sdp.lines().anyMatch(line -> {
+            String stripped = line.strip();
+            return stripped.equals("a=sendonly") || stripped.equals("a=inactive");
+        });
+    }
+
+    private static void sendOkWithDirection(SipServletRequest req, CallMedia media, String direction)
+            throws IOException {
+        String sdpAnswer = replaceDirection(media.sdpAnswer(), direction);
+        SipServletResponse response = req.createResponse(SipServletResponse.SC_OK);
+        response.setContent(sdpAnswer.getBytes(StandardCharsets.UTF_8), "application/sdp");
+        response.send();
+    }
+
+    /**
+     * Replaces the {@code a=sendrecv}, {@code a=sendonly}, {@code a=recvonly}, or
+     * {@code a=inactive} attribute line in the SDP answer with the given direction.
+     * If none of those lines is present, appends the direction before the end of the string.
+     */
+    static String replaceDirection(String sdpAnswer, String direction) {
+        String newLine = "a=" + direction;
+
+        for (String candidate : new String[] {"a=sendrecv", "a=sendonly", "a=recvonly", "a=inactive"}) {
+            if (sdpAnswer.contains(candidate)) {
+                return sdpAnswer.replace(candidate, newLine);
+            }
+        }
+
+        return sdpAnswer + newLine + "\r\n";
+    }
+
+    private static String readSdpBody(SipServletRequest req) throws IOException {
+        Object content = req.getContent();
+
+        if (content instanceof byte[] bytes) {
+            return new String(bytes, StandardCharsets.UTF_8);
+        }
+
+        return String.valueOf(content);
+    }
+}

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/HoldHandler.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/HoldHandler.java
@@ -106,7 +106,7 @@ public class HoldHandler {
 
     /**
      * Returns {@code true} when the SDP offer indicates the caller is placing the call on hold.
-     * Checks for {@code a=sendonly} or {@code a=inactive} in the media section.
+     * Checks for {@code a=sendonly} or {@code a=inactive} anywhere in the SDP body.
      */
     static boolean isHoldOffer(String sdp) {
         return sdp.lines().anyMatch(line -> {

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
@@ -15,6 +15,7 @@ package de.bmarwell.proximo.pitido.war.media;
 import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Holds the negotiated media parameters for one call leg.
@@ -22,21 +23,55 @@ import java.net.InetSocketAddress;
  * <p>Created by {@link SdpNegotiator} from the SDP offer in the incoming INVITE.
  * The caller is responsible for closing {@link #localSocket()} when the call ends.
  *
- * @param localSocket                the bound UDP socket used for RTP transmission; must be closed
- *                                   after the call
- * @param remoteRtp                  the remote endpoint's RTP address and port, from the SDP
- *                                   {@code c=} and {@code m=audio} lines
- * @param sdpAnswer                  the fully formatted SDP answer body to include in the 200 OK
- *                                   response
- * @param codec                      the negotiated RTP codec; determines payload type, encoding,
- *                                   and clock rate
- * @param telephoneEventPayloadType  the dynamic RTP payload type negotiated for RFC 4733
- *                                   telephone-event, or {@code -1} if the remote side did not
- *                                   offer telephone-event in its SDP
+ * <p>{@link #held} is an {@link AtomicBoolean} embedded in this record.
+ * The record keeps its identity (the reference is final) while the hold state is
+ * mutated thread-safely by the SIP thread (re-INVITE handler) concurrently with
+ * the RTP send thread.
+ * Use {@link #hold()}, {@link #unhold()}, and {@link #isHeld()} rather than accessing
+ * the component directly.
+ *
+ * @param localSocket               the bound UDP socket used for RTP transmission; must be
+ *                                  closed after the call
+ * @param remoteRtp                 the remote endpoint's RTP address and port, from the SDP
+ *                                  {@code c=} and {@code m=audio} lines
+ * @param sdpAnswer                 the fully formatted SDP answer body to include in the 200 OK
+ *                                  response
+ * @param codec                     the negotiated RTP codec; determines payload type, encoding,
+ *                                  and clock rate
+ * @param telephoneEventPayloadType the dynamic RTP payload type negotiated for RFC 4733
+ *                                  telephone-event, or {@code -1} if the remote side did not
+ *                                  offer telephone-event in its SDP
+ * @param held                      thread-safe hold flag; mutated via {@link #hold()} and
+ *                                  {@link #unhold()}, never replaced
  */
 public record CallMedia(
         DatagramSocket localSocket,
         InetSocketAddress remoteRtp,
         String sdpAnswer,
         RtpCodec codec,
-        int telephoneEventPayloadType) {}
+        int telephoneEventPayloadType,
+        AtomicBoolean held) {
+
+    /**
+     * Pauses RTP transmission.
+     * The audio sender will stop sending packets and pause PCM consumption until
+     * {@link #unhold()} is called.
+     */
+    public void hold() {
+        this.held.set(true);
+    }
+
+    /**
+     * Resumes RTP transmission after a hold.
+     */
+    public void unhold() {
+        this.held.set(false);
+    }
+
+    /**
+     * Returns {@code true} when the call is currently on hold.
+     */
+    public boolean isHeld() {
+        return this.held.get();
+    }
+}

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpAudioPlayer.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpAudioPlayer.java
@@ -58,6 +58,7 @@ public class RtpAudioPlayer implements AudioPlayer {
     private final InetSocketAddress remoteRtp;
     private final PcmDecoderFactory pcmDecoderFactory;
     private final RtpCodec codec;
+    private final CallMedia callMedia;
     private final int ssrc;
     private int seqNumber;
     private long timestamp;
@@ -70,6 +71,7 @@ public class RtpAudioPlayer implements AudioPlayer {
      * @param pcmDecoderFactory the factory used to select the decoder for each audio resource
      */
     public RtpAudioPlayer(CallMedia callMedia, PcmDecoderFactory pcmDecoderFactory) {
+        this.callMedia = callMedia;
         this.socket = callMedia.localSocket();
         this.remoteRtp = callMedia.remoteRtp();
         this.pcmDecoderFactory = pcmDecoderFactory;
@@ -152,6 +154,14 @@ public class RtpAudioPlayer implements AudioPlayer {
             while (true) {
                 if (Thread.currentThread().isInterrupted()) {
                     throw new InterruptedException("RTP playback interrupted");
+                }
+
+                if (this.callMedia.isHeld()) {
+                    // Call is on hold: pause PCM consumption and RTP sending.
+                    // Advance the RTP timestamp so the timeline stays consistent on resume.
+                    this.timestamp += this.codec.rtpTimestampIncrement();
+                    Thread.sleep(20);
+                    continue;
                 }
 
                 int read = readFrame(pcm, decoderFrameBuf, decoderSamplesPerPacket);

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpAudioPlayer.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpAudioPlayer.java
@@ -109,6 +109,12 @@ public class RtpAudioPlayer implements AudioPlayer {
                 throw new InterruptedException("RTP silence interrupted");
             }
 
+            if (this.callMedia.isHeld()) {
+                this.timestamp += this.codec.rtpTimestampIncrement();
+                Thread.sleep(20);
+                continue;
+            }
+
             try {
                 sendRtpPacket(this.codec.encode(silenceFrame));
             } catch (IOException ioException) {

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
@@ -102,7 +103,7 @@ public class SdpNegotiator {
         String sdpAnswer = buildSdpAnswer(localIp, localPort, codec, telephoneEventPt);
         InetSocketAddress remoteAddr = new InetSocketAddress(remoteIp, remotePort);
 
-        return new CallMedia(localSocket, remoteAddr, sdpAnswer, codec, telephoneEventPt);
+        return new CallMedia(localSocket, remoteAddr, sdpAnswer, codec, telephoneEventPt, new AtomicBoolean(false));
     }
 
     private static String readSdpBody(SipServletRequest req) throws IOException {

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.war.listener;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class HoldHandlerTest {
+
+    @Test
+    void isHoldOffer_sendonly_returnsTrue() {
+        // given
+        String sdp = "v=0\r\nm=audio 10000 RTP/AVP 8\r\na=sendonly\r\n";
+
+        // when
+        boolean result = HoldHandler.isHoldOffer(sdp);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    void isHoldOffer_inactive_returnsTrue() {
+        // given
+        String sdp = "v=0\r\nm=audio 10000 RTP/AVP 8\r\na=inactive\r\n";
+
+        // when
+        boolean result = HoldHandler.isHoldOffer(sdp);
+
+        // then
+        assertTrue(result);
+    }
+
+    @Test
+    void isHoldOffer_sendrecv_returnsFalse() {
+        // given
+        String sdp = "v=0\r\nm=audio 10000 RTP/AVP 8\r\na=sendrecv\r\n";
+
+        // when
+        boolean result = HoldHandler.isHoldOffer(sdp);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    void isHoldOffer_noDirectionAttribute_returnsFalse() {
+        // given
+        String sdp = "v=0\r\nm=audio 10000 RTP/AVP 8\r\n";
+
+        // when
+        boolean result = HoldHandler.isHoldOffer(sdp);
+
+        // then
+        assertFalse(result);
+    }
+
+    @Test
+    void replaceDirection_replacesExistingSendrecv() {
+        // given
+        String sdpAnswer = "v=0\r\na=sendrecv\r\n";
+
+        // when
+        String result = HoldHandler.replaceDirection(sdpAnswer, "recvonly");
+
+        // then
+        assertEquals("v=0\r\na=recvonly\r\n", result);
+    }
+
+    @Test
+    void replaceDirection_replacesExistingSendonly() {
+        // given
+        String sdpAnswer = "v=0\r\na=sendonly\r\n";
+
+        // when
+        String result = HoldHandler.replaceDirection(sdpAnswer, "sendrecv");
+
+        // then
+        assertEquals("v=0\r\na=sendrecv\r\n", result);
+    }
+
+    @Test
+    void replaceDirection_appendsWhenNoDirectionPresent() {
+        // given
+        String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\n";
+
+        // when
+        String result = HoldHandler.replaceDirection(sdpAnswer, "recvonly");
+
+        // then
+        assertEquals("v=0\r\nm=audio 5000 RTP/AVP 8\r\na=recvonly\r\n", result);
+    }
+}

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
@@ -15,10 +15,142 @@ package de.bmarwell.proximo.pitido.war.listener;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import de.bmarwell.proximo.pitido.war.media.CallMedia;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
+import javax.servlet.sip.SipServletRequest;
+import javax.servlet.sip.SipServletResponse;
+import javax.servlet.sip.SipSession;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class HoldHandlerTest {
+
+    @Mock
+    CallSessionManager callSessionManager;
+
+    @Mock
+    SipServletRequest req;
+
+    @Mock
+    SipSession sipSession;
+
+    @Mock
+    SipServletResponse response;
+
+    @InjectMocks
+    HoldHandler holdHandler;
+
+    // ── handle() tests ────────────────────────────────────────────────────────
+
+    @Test
+    void handle_holdOffer_pausesMediaAndResponds200WithRecvonly() throws IOException {
+        // given
+        String sdpOffer = "v=0\r\nm=audio 10000 RTP/AVP 8\r\na=sendonly\r\n";
+        String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=sendrecv\r\n";
+        AtomicBoolean held = new AtomicBoolean(false);
+        CallMedia media = new CallMedia(null, null, sdpAnswer, null, -1, held);
+        CallState callState =
+                new CallState(sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
+        when(sipSession.getId()).thenReturn("sess-1");
+        when(req.getSession()).thenReturn(sipSession);
+        when(req.getContent()).thenReturn(sdpOffer.getBytes(StandardCharsets.UTF_8));
+        when(req.createResponse(SipServletResponse.SC_OK)).thenReturn(response);
+        when(callSessionManager.get("sess-1")).thenReturn(callState);
+
+        // when
+        holdHandler.handle(req);
+
+        // then
+        assertTrue(held.get(), "media must be held");
+        ArgumentCaptor<byte[]> sdpCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(response).setContent(sdpCaptor.capture(), org.mockito.ArgumentMatchers.anyString());
+        String responseSdp = new String(sdpCaptor.getValue(), StandardCharsets.UTF_8);
+        assertTrue(responseSdp.contains("a=recvonly"), "response SDP must contain a=recvonly");
+        verify(response).send();
+    }
+
+    @Test
+    void handle_inactiveOffer_pausesMediaAndResponds200WithInactive() throws IOException {
+        // given
+        String sdpOffer = "v=0\r\nm=audio 10000 RTP/AVP 8\r\na=inactive\r\n";
+        String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=sendrecv\r\n";
+        AtomicBoolean held = new AtomicBoolean(false);
+        CallMedia media = new CallMedia(null, null, sdpAnswer, null, -1, held);
+        CallState callState =
+                new CallState(sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
+        when(sipSession.getId()).thenReturn("sess-2");
+        when(req.getSession()).thenReturn(sipSession);
+        when(req.getContent()).thenReturn(sdpOffer.getBytes(StandardCharsets.UTF_8));
+        when(req.createResponse(SipServletResponse.SC_OK)).thenReturn(response);
+        when(callSessionManager.get("sess-2")).thenReturn(callState);
+
+        // when
+        holdHandler.handle(req);
+
+        // then
+        assertTrue(held.get(), "media must be held");
+        ArgumentCaptor<byte[]> sdpCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(response).setContent(sdpCaptor.capture(), org.mockito.ArgumentMatchers.anyString());
+        String responseSdp = new String(sdpCaptor.getValue(), StandardCharsets.UTF_8);
+        assertTrue(responseSdp.contains("a=inactive"), "response SDP must contain a=inactive");
+        verify(response).send();
+    }
+
+    @Test
+    void handle_resumeOffer_resumesMediaAndResponds200WithSendrecv() throws IOException {
+        // given
+        String sdpOffer = "v=0\r\nm=audio 10000 RTP/AVP 8\r\na=sendrecv\r\n";
+        String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=recvonly\r\n";
+        AtomicBoolean held = new AtomicBoolean(true);
+        CallMedia media = new CallMedia(null, null, sdpAnswer, null, -1, held);
+        CallState callState =
+                new CallState(sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
+        when(sipSession.getId()).thenReturn("sess-3");
+        when(req.getSession()).thenReturn(sipSession);
+        when(req.getContent()).thenReturn(sdpOffer.getBytes(StandardCharsets.UTF_8));
+        when(req.createResponse(SipServletResponse.SC_OK)).thenReturn(response);
+        when(callSessionManager.get("sess-3")).thenReturn(callState);
+
+        // when
+        holdHandler.handle(req);
+
+        // then
+        assertFalse(held.get(), "media must be un-held");
+        ArgumentCaptor<byte[]> sdpCaptor = ArgumentCaptor.forClass(byte[].class);
+        verify(response).setContent(sdpCaptor.capture(), org.mockito.ArgumentMatchers.anyString());
+        String responseSdp = new String(sdpCaptor.getValue(), StandardCharsets.UTF_8);
+        assertTrue(responseSdp.contains("a=sendrecv"), "response SDP must contain a=sendrecv");
+        verify(response).send();
+    }
+
+    @Test
+    void handle_unknownSession_responds481() throws IOException {
+        // given
+        when(sipSession.getId()).thenReturn("unknown-sess");
+        when(req.getSession()).thenReturn(sipSession);
+        when(callSessionManager.get("unknown-sess")).thenReturn(null);
+        when(req.createResponse(SipServletResponse.SC_CALL_LEG_DONE)).thenReturn(response);
+
+        // when
+        holdHandler.handle(req);
+
+        // then
+        verify(response).send();
+    }
+
+    // ── isHoldOffer() static helper tests ─────────────────────────────────────
 
     @Test
     void isHoldOffer_sendonly_returnsTrue() {
@@ -67,6 +199,8 @@ class HoldHandlerTest {
         // then
         assertFalse(result);
     }
+
+    // ── replaceDirection() static helper tests ────────────────────────────────
 
     @Test
     void replaceDirection_replacesExistingSendrecv() {


### PR DESCRIPTION
Closes #33.

## Changes

- **`CallMedia`** — converted from `record` to class; added thread-safe `hold()`/`unhold()`/`isHeld()` backed by `AtomicBoolean`
- **`RtpAudioPlayer`** — in `playBlocking()` loop: when held, skip PCM read and RTP send but still tick the timestamp every 20 ms so the RTP timeline is correct on resume
- **`HoldHandler`** (new `@ApplicationScoped` bean) — parses SDP direction (`a=sendonly`/`a=inactive` = hold; `a=recvonly`/`a=sendrecv` = resume), pauses or resumes media, responds 200 OK with updated direction
- **`CallAcceptor.accept()`** — checks if session already exists in `CallSessionManager`; if so, delegates to `HoldHandler` instead of treating it as a new call
- **`HoldHandlerTest`** — unit tests for `isHoldOffer()` and `replaceDirection()`