### PR TITLE
feat: document TZ env var for configurable timezone

### DIFF
--- a/README.adoc
+++ b/README.adoc
@@ -152,6 +152,20 @@ OPTIONS:   ("Proximo Pitido", "DAR:From", "NEUTRAL", "", "NO_ROUTE", "0")
 
 `server.env` is intentionally excluded from version control (contains secrets).
 
+=== Timezone
+
+The announced time uses the JVM default timezone, which OpenJDK on Linux resolves in this order:
+
+. `TZ` environment variable — the standard Docker mechanism.
+  Set `TZ=Europe/Berlin` in `docker-compose.yml` or pass `-e TZ=Europe/Berlin` to `docker run`.
+. `/etc/localtime` inside the container — stock Docker images default to UTC.
+
+Without `TZ`, callers will hear the time in UTC.
+Use IANA timezone IDs such as `Europe/Berlin`, `Europe/London`, `America/New_York`, or `Asia/Tokyo`.
+
+NOTE: `user.country` and `user.region` are locale settings for language formatting (decimal separators, date order, etc.).
+They have no effect on timezone resolution.
+
 == Known quirks
 
 * Liberty `sipEndpoint host="*"` resolves to `127.0.1.1` on this system — bind to the LAN IP explicitly via `SIP_LOCAL_HOST`.
@@ -202,3 +216,25 @@ a|Enable EPEL first, then: +
 Falls back to the built-in Java mixer when absent.
 The FFM binding is not yet implemented; the library is detected but the Java path is used unconditionally for now.
 |===
+
+== Running with Docker
+
+A minimal `docker-compose.yml` example:
+
+[source,yaml]
+----
+services:
+  proximo-pitido:
+    image: ghcr.io/bmarwell/proximo-pitido:latest
+    environment:
+      TZ: "Europe/Berlin"
+      SIP_REGISTRAR: "tel.t-online.de"
+      SIP_SIPID: "4915112345678"
+      SIP_USER_ID: "4915112345678@t-online.de"
+      SIP_USER_PASSWORD: "secret"
+      SIP_LOCAL_HOST: "192.168.1.100"
+    network_mode: host
+----
+
+`TZ` must be set to an https://en.wikipedia.org/wiki/List_of_tz_database_time_zones[IANA timezone ID].
+Without it, the container defaults to UTC and callers hear the time in UTC.

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/AnnouncementLoop.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/AnnouncementLoop.java
@@ -31,6 +31,23 @@ import javax.servlet.sip.SipSession;
  *
  * <p>On exit (for any reason), removes the session from {@link CallSessionManager} and closes
  * the media socket so no resources leak.
+ *
+ * <h2>Timezone</h2>
+ *
+ * <p>{@link Clock#systemDefaultZone()} is used to obtain the current local time.
+ * OpenJDK on Linux resolves the JVM default timezone in the following order:
+ *
+ * <ol>
+ *   <li>{@code TZ} environment variable — set this in {@code docker-compose.yml} or via
+ *       {@code docker run -e TZ=Europe/Berlin} to configure the announced timezone.</li>
+ *   <li>{@code /etc/localtime} — the container or OS default.
+ *       Stock Docker images default to UTC, which is why announcements are in UTC when
+ *       {@code TZ} is not set.</li>
+ * </ol>
+ *
+ * <p>Note: {@code user.country} and {@code user.region} are locale settings that control
+ * language formatting (decimal separators, date order, etc.) but have <em>no effect</em>
+ * on timezone resolution.
  */
 @ApplicationScoped
 public class AnnouncementLoop {


### PR DESCRIPTION
Closes #42

## Summary

`Clock.systemDefaultZone()` already reads the `TZ` environment variable on Linux — **no code change was necessary**.

## Changes

- **`AnnouncementLoop` Javadoc**: explains the JVM timezone resolution order (`TZ` → `/etc/localtime`), notes that `user.country`/`user.region` have no effect on timezone resolution, and directs operators to set `TZ`.
- **`README.adoc`**: adds a _Timezone_ subsection under _Configuration_ explaining the resolution order with examples; adds a new _Running with Docker_ section with a `docker-compose.yml` snippet showing `TZ=Europe/Berlin`.