### PR TITLE
fix(core): auto-discover public IP via java.net.http.HttpClient

### DIFF
--- a/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
+++ b/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
@@ -24,9 +24,19 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 /**
  * Provides the local SIP host address to use in the SIP {@code Contact} header.
  *
- * <p>Prefers the {@code sip.public.host} / {@code SIP_PUBLIC_HOST} config property (the
- * public-facing address behind NAT). Falls back to auto-detecting the first non-loopback,
- * non-link-local IPv4 address on any active network interface.
+ * <p>Address resolution priority:
+ *
+ * <ol>
+ *   <li>{@code SIP_PUBLIC_HOST} / {@code sip.public.host} — explicit operator override; used
+ *       as-is without any network call.</li>
+ *   <li>Public IP auto-detected via {@link PublicIpDiscoveryService} — used when
+ *       {@code SIP_REGISTRATION_ENABLED=true} and {@code SIP_PUBLIC_HOST} is absent.
+ *       Behind NAT (home router, Docker host), a local IP in the Contact header is unreachable
+ *       from the registrar, so a public IP is necessary.</li>
+ *   <li>First non-loopback, non-link-local IPv4 address on any active network interface —
+ *       used when registration is disabled (softphone / dev mode) or when all public-IP
+ *       discovery services are unreachable.</li>
+ * </ol>
  */
 @ApplicationScoped
 public class LocalSipHostProvider {
@@ -39,19 +49,47 @@ public class LocalSipHostProvider {
     @ConfigProperty(name = "sip.public.host")
     Optional<String> configuredHost;
 
+    @Inject
+    @ConfigProperty(name = "sip.registration.enabled", defaultValue = "true")
+    boolean registrationEnabled;
+
+    @Inject
+    PublicIpDiscoveryService publicIpDiscoveryService;
+
     /** CDI no-args constructor. */
     public LocalSipHostProvider() {}
 
     /** Returns the address to advertise in the SIP {@code Contact} header. */
     public String get() {
-        return configuredHost.orElseGet(this::detectLocalAddress);
+        if (this.configuredHost.isPresent()) {
+            return this.configuredHost.get();
+        }
+
+        if (!this.registrationEnabled) {
+            return detectLocalAddress();
+        }
+
+        Optional<String> publicIp = this.publicIpDiscoveryService.discover();
+
+        if (publicIp.isPresent()) {
+            return publicIp.get();
+        }
+
+        LOGGER.log(
+                System.Logger.Level.WARNING,
+                "All public IP discovery services unreachable; falling back to local IP for Contact header."
+                        + " Incoming calls may fail if this host is behind NAT.");
+        return detectLocalAddress();
     }
 
     private String detectLocalAddress() {
         try {
             return findLocalIpv4Address().orElse(FALLBACK_ADDRESS);
-        } catch (SocketException ex) {
-            LOGGER.log(System.Logger.Level.WARNING, "Could not auto-detect local SIP host, using loopback", ex);
+        } catch (SocketException socketException) {
+            LOGGER.log(
+                    System.Logger.Level.WARNING,
+                    "Could not auto-detect local SIP host, using loopback",
+                    socketException);
             return FALLBACK_ADDRESS;
         }
     }
@@ -70,7 +108,7 @@ public class LocalSipHostProvider {
     private boolean isUsableInterface(NetworkInterface ni) {
         try {
             return ni.isUp() && !ni.isLoopback() && !ni.isVirtual();
-        } catch (SocketException ex) {
+        } catch (SocketException socketException) {
             return false;
         }
     }

--- a/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/PublicIpDiscoveryService.java
+++ b/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/PublicIpDiscoveryService.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.core.sip;
+
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.PostConstruct;
+import javax.enterprise.context.ApplicationScoped;
+
+/**
+ * Discovers the public IPv4 address of this host by querying well-known plain-text IP-echo services.
+ *
+ * <p>Services are tried in order; the first successful, valid response is used.
+ * The result is cached for {@value #CACHE_HOURS} hour so that repeated calls during a registration
+ * cycle do not generate unnecessary HTTP traffic.
+ *
+ * <p>Each HTTP request times out after {@value #REQUEST_TIMEOUT_SECONDS} seconds.
+ * A failed request is logged at DEBUG level and the next service is tried.
+ * When all services fail, {@link Optional#empty()} is returned; the caller is responsible for
+ * falling back to a locally detected address.
+ *
+ * <h2>Services queried (in order)</h2>
+ *
+ * <ol>
+ *   <li>{@code https://ident.me} — plain text, IPv4 or IPv6</li>
+ *   <li>{@code https://api.ipify.org} — plain text, IPv4 only</li>
+ *   <li>{@code https://checkip.amazonaws.com} — plain text, IPv4 only</li>
+ * </ol>
+ */
+@ApplicationScoped
+public class PublicIpDiscoveryService {
+
+    private static final System.Logger LOGGER = System.getLogger(PublicIpDiscoveryService.class.getName());
+
+    static final List<String> DISCOVERY_URLS =
+            List.of("https://ident.me", "https://api.ipify.org", "https://checkip.amazonaws.com");
+
+    private static final int CACHE_HOURS = 1;
+    private static final long REQUEST_TIMEOUT_SECONDS = 2L;
+
+    /** The HTTP client; initialised in {@link #init()} and shared across all discovery calls. */
+    HttpClient httpClient;
+
+    private final AtomicReference<String> cachedIp = new AtomicReference<>();
+    private volatile Instant cacheExpiry = Instant.MIN;
+
+    /** CDI no-args constructor. */
+    public PublicIpDiscoveryService() {}
+
+    @PostConstruct
+    void init() {
+        this.httpClient = HttpClient.newBuilder()
+                .connectTimeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS))
+                .build();
+    }
+
+    /**
+     * Returns the public IP address of this host, querying remote services if the cache is stale.
+     *
+     * @return the discovered IP address, or {@link Optional#empty()} when all services are
+     *     unreachable
+     */
+    public Optional<String> discover() {
+        String cached = this.cachedIp.get();
+
+        if (cached != null && Instant.now().isBefore(this.cacheExpiry)) {
+            return Optional.of(cached);
+        }
+
+        return queryDiscoveryServices();
+    }
+
+    private Optional<String> queryDiscoveryServices() {
+        for (String url : DISCOVERY_URLS) {
+            Optional<String> ip = queryService(url);
+
+            if (ip.isPresent()) {
+                this.cachedIp.set(ip.get());
+                this.cacheExpiry = Instant.now().plus(Duration.ofHours(CACHE_HOURS));
+                return ip;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<String> queryService(String url) {
+        try {
+            HttpRequest request = HttpRequest.newBuilder()
+                    .uri(URI.create(url))
+                    .timeout(Duration.ofSeconds(REQUEST_TIMEOUT_SECONDS))
+                    .GET()
+                    .build();
+
+            HttpResponse<String> response = this.httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+
+            String body = response.body().strip();
+
+            if (!isValidIpAddress(body)) {
+                LOGGER.log(System.Logger.Level.DEBUG, "Unexpected response from {0}: {1}", url, body);
+                return Optional.empty();
+            }
+
+            LOGGER.log(System.Logger.Level.INFO, "Discovered public IP {0} via {1}", body, url);
+            return Optional.of(body);
+        } catch (Exception exception) {
+            LOGGER.log(
+                    System.Logger.Level.DEBUG, "Failed to query public IP from {0}: {1}", url, exception.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private static boolean isValidIpAddress(String candidate) {
+        if (candidate == null || candidate.isBlank() || candidate.length() > 45) {
+            return false;
+        }
+
+        try {
+            InetAddress.getByName(candidate);
+            return true;
+        } catch (UnknownHostException unknownHostException) {
+            return false;
+        }
+    }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -26,6 +26,7 @@ module de.bmarwell.proximo.pitido.core {
 
     // JDK platform modules
     requires java.naming; // javax.naming.* — JNDI SRV DNS lookup (package-private use only)
+    requires java.net.http; // java.net.http.HttpClient — public IP discovery
 
     // MicroProfile Config — provided by Liberty; annotation-only use (@ConfigProperty)
     requires static microprofile.config.api;

--- a/core/src/test/java/de/bmarwell/proximo/pitido/core/sip/PublicIpDiscoveryServiceTest.java
+++ b/core/src/test/java/de/bmarwell/proximo/pitido/core/sip/PublicIpDiscoveryServiceTest.java
@@ -1,0 +1,144 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.core.sip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PublicIpDiscoveryServiceTest {
+
+    @Mock
+    HttpClient httpClient;
+
+    @Mock
+    HttpResponse<String> httpResponse;
+
+    @InjectMocks
+    PublicIpDiscoveryService discoveryService;
+
+    @SuppressWarnings("unchecked")
+    private void givenResponse(String body) throws IOException, InterruptedException {
+        when(this.httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(this.httpResponse);
+        when(this.httpResponse.body()).thenReturn(body);
+    }
+
+    @Test
+    void discover_firstServiceRespondsWithValidIp_returnsThatIp() throws Exception {
+        // given
+        givenResponse("1.2.3.4");
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals("1.2.3.4", result.get());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void discover_firstServiceFails_triesNextAndReturnsItsIp() throws Exception {
+        // given
+        when(this.httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenThrow(new IOException("connection refused"))
+                .thenReturn(this.httpResponse);
+        when(this.httpResponse.body()).thenReturn("5.6.7.8");
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals("5.6.7.8", result.get());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void discover_allServicesFail_returnsEmpty() throws Exception {
+        // given
+        when(this.httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenThrow(new IOException("no route to host"));
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void discover_serviceReturnsInvalidBody_skipsToNextService() throws Exception {
+        // given
+        HttpResponse<String> secondResponse = org.mockito.Mockito.mock(HttpResponse.class);
+        when(this.httpClient.send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class)))
+                .thenReturn(this.httpResponse)
+                .thenReturn(secondResponse);
+        when(this.httpResponse.body()).thenReturn("not-an-ip-address");
+        when(secondResponse.body()).thenReturn("9.10.11.12");
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals("9.10.11.12", result.get());
+    }
+
+    @Test
+    @SuppressWarnings("unchecked")
+    void discover_secondCallWithinCacheWindow_doesNotQueryRemoteServices() throws Exception {
+        // given
+        givenResponse("1.2.3.4");
+        this.discoveryService.discover();
+
+        // when
+        Optional<String> cached = this.discoveryService.discover();
+
+        // then
+        assertTrue(cached.isPresent());
+        assertEquals("1.2.3.4", cached.get());
+        verify(this.httpClient, times(1)).send(any(HttpRequest.class), any(HttpResponse.BodyHandler.class));
+    }
+
+    @Test
+    void discover_responseWithTrailingNewline_isStrippedAndAccepted() throws Exception {
+        // given
+        givenResponse("203.0.113.1\n");
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals("203.0.113.1", result.get());
+    }
+}


### PR DESCRIPTION
Closes #24

## What

Adds `PublicIpDiscoveryService` — an `@ApplicationScoped` CDI bean that queries plain-text IP-echo services in order to determine the public IP for the SIP `Contact` header.

Uses the built-in `java.net.http.HttpClient` (Java 11+, standard JDK module). `javax.ws.rs-api:2.1.1` was evaluated but rejected: its `module-info.class` declares `requires transitive java.xml.bind`, which was removed in Java 17 and is unavailable in Java 25.

## Resolution order in `LocalSipHostProvider.get()`

1. `SIP_PUBLIC_HOST` / `sip.public.host` — explicit operator override, no network call
2. `PublicIpDiscoveryService.discover()` — when `sip.registration.enabled=true` (default)
3. First non-loopback IPv4 from local network interfaces — fallback with WARNING log when behind NAT and all discovery services are unreachable

## Details

- Services tried in order: `ident.me`, `api.ipify.org`, `checkip.amazonaws.com`
- 2-second connect + read timeout per request
- 1-hour in-memory cache (`AtomicReference` + `volatile Instant`)
- Response validated via `InetAddress.getByName()` before use
- 6 unit tests covering: first service, fallback, all-fail, invalid body, caching, trailing newline