### PR TITLE
fix(core): auto-discover public IP via JAX-RS client

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -38,6 +38,27 @@
       <artifactId>microprofile-config-api</artifactId>
       <scope>provided</scope>
     </dependency>
+
+    <!-- JAX-RS 2.1 client API — provided at runtime by Liberty's jaxrsClient feature -->
+    <dependency>
+      <groupId>javax.ws.rs</groupId>
+      <artifactId>javax.ws.rs-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- JAXB API — satisfies the compile-time java.xml.bind transitive requirement from javax.ws.rs-api -->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+    <!-- Apache CXF: JAX-RS client implementation for tests -->
+    <dependency>
+      <groupId>org.apache.cxf</groupId>
+      <artifactId>cxf-rt-rs-client</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
+++ b/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
@@ -24,9 +24,19 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
 /**
  * Provides the local SIP host address to use in the SIP {@code Contact} header.
  *
- * <p>Prefers the {@code sip.public.host} / {@code SIP_PUBLIC_HOST} config property (the
- * public-facing address behind NAT). Falls back to auto-detecting the first non-loopback,
- * non-link-local IPv4 address on any active network interface.
+ * <p>Address resolution priority:
+ *
+ * <ol>
+ *   <li>{@code SIP_PUBLIC_HOST} / {@code sip.public.host} — explicit operator override; used
+ *       as-is without any network call.</li>
+ *   <li>Public IP auto-detected via {@link PublicIpDiscoveryService} — used when
+ *       {@code SIP_REGISTRATION_ENABLED=true} and {@code SIP_PUBLIC_HOST} is absent.
+ *       Behind NAT (home router, Docker host), a local IP in the Contact header is unreachable
+ *       from the registrar, so a public IP is necessary.</li>
+ *   <li>First non-loopback, non-link-local IPv4 address on any active network interface —
+ *       used when registration is disabled (softphone / dev mode) or when all public-IP
+ *       discovery services are unreachable.</li>
+ * </ol>
  */
 @ApplicationScoped
 public class LocalSipHostProvider {
@@ -39,19 +49,47 @@ public class LocalSipHostProvider {
     @ConfigProperty(name = "sip.public.host")
     Optional<String> configuredHost;
 
+    @Inject
+    @ConfigProperty(name = "sip.registration.enabled", defaultValue = "true")
+    boolean registrationEnabled;
+
+    @Inject
+    PublicIpDiscoveryService publicIpDiscoveryService;
+
     /** CDI no-args constructor. */
     public LocalSipHostProvider() {}
 
     /** Returns the address to advertise in the SIP {@code Contact} header. */
     public String get() {
-        return configuredHost.orElseGet(this::detectLocalAddress);
+        if (this.configuredHost.isPresent()) {
+            return this.configuredHost.get();
+        }
+
+        if (!this.registrationEnabled) {
+            return detectLocalAddress();
+        }
+
+        Optional<String> publicIp = this.publicIpDiscoveryService.discover();
+
+        if (publicIp.isPresent()) {
+            return publicIp.get();
+        }
+
+        LOGGER.log(
+                System.Logger.Level.WARNING,
+                "All public IP discovery services unreachable; falling back to local IP for Contact header."
+                        + " Incoming calls may fail if this host is behind NAT.");
+        return detectLocalAddress();
     }
 
     private String detectLocalAddress() {
         try {
             return findLocalIpv4Address().orElse(FALLBACK_ADDRESS);
-        } catch (SocketException ex) {
-            LOGGER.log(System.Logger.Level.WARNING, "Could not auto-detect local SIP host, using loopback", ex);
+        } catch (SocketException socketException) {
+            LOGGER.log(
+                    System.Logger.Level.WARNING,
+                    "Could not auto-detect local SIP host, using loopback",
+                    socketException);
             return FALLBACK_ADDRESS;
         }
     }
@@ -70,7 +108,7 @@ public class LocalSipHostProvider {
     private boolean isUsableInterface(NetworkInterface ni) {
         try {
             return ni.isUp() && !ni.isLoopback() && !ni.isVirtual();
-        } catch (SocketException ex) {
+        } catch (SocketException socketException) {
             return false;
         }
     }

--- a/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/PublicIpDiscoveryService.java
+++ b/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/PublicIpDiscoveryService.java
@@ -12,7 +12,9 @@
  */
 package de.bmarwell.proximo.pitido.core.sip;
 
+import java.net.Inet4Address;
 import java.net.InetAddress;
+import java.net.URI;
 import java.net.UnknownHostException;
 import java.time.Duration;
 import java.time.Instant;
@@ -20,8 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicReference;
-import javax.annotation.PostConstruct;
-import javax.annotation.PreDestroy;
+import java.util.function.Supplier;
 import javax.enterprise.context.ApplicationScoped;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
@@ -35,7 +36,9 @@ import javax.ws.rs.core.MediaType;
  * The result is cached for {@value #CACHE_HOURS} hour so that repeated calls during a registration
  * cycle do not generate unnecessary HTTP traffic.
  *
- * <p>Each HTTP request times out after {@value #REQUEST_TIMEOUT_SECONDS} seconds.
+ * <p>A fresh JAX-RS {@link Client} is created for each {@link #discover()} invocation and closed
+ * immediately afterwards.
+ * Each HTTP request times out after {@value #REQUEST_TIMEOUT_SECONDS} seconds.
  * A failed request is logged at DEBUG level and the next service is tried.
  * When all services fail, {@link Optional#empty()} is returned; the caller is responsible for
  * falling back to a locally detected address.
@@ -43,7 +46,7 @@ import javax.ws.rs.core.MediaType;
  * <h2>Services queried (in order)</h2>
  *
  * <ol>
- *   <li>{@code https://ident.me} — plain text, IPv4 or IPv6</li>
+ *   <li>{@code https://v4.ident.me} — plain text, IPv4 only</li>
  *   <li>{@code https://api.ipify.org} — plain text, IPv4 only</li>
  *   <li>{@code https://checkip.amazonaws.com} — plain text, IPv4 only</li>
  * </ol>
@@ -53,14 +56,22 @@ public class PublicIpDiscoveryService {
 
     private static final System.Logger LOGGER = System.getLogger(PublicIpDiscoveryService.class.getName());
 
-    static final List<String> DISCOVERY_URLS =
-            List.of("https://ident.me", "https://api.ipify.org", "https://checkip.amazonaws.com");
+    static final List<URI> DISCOVERY_URLS = List.of(
+            URI.create("https://v4.ident.me"),
+            URI.create("https://api.ipify.org"),
+            URI.create("https://checkip.amazonaws.com"));
 
     private static final int CACHE_HOURS = 1;
     private static final long REQUEST_TIMEOUT_SECONDS = 2L;
 
-    /** The JAX-RS client; created in {@link #init()} and closed in {@link #close()}. */
-    Client client;
+    /**
+     * Factory used to create a short-lived JAX-RS {@link Client} per discovery invocation.
+     * Package-private so tests can substitute a supplier that returns a mock client.
+     */
+    Supplier<Client> clientFactory = () -> ClientBuilder.newBuilder()
+            .connectTimeout(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .build();
 
     private final AtomicReference<String> cachedIp = new AtomicReference<>();
     private volatile Instant cacheExpiry = Instant.MIN;
@@ -68,25 +79,10 @@ public class PublicIpDiscoveryService {
     /** CDI no-args constructor. */
     public PublicIpDiscoveryService() {}
 
-    @PostConstruct
-    void init() {
-        this.client = ClientBuilder.newBuilder()
-                .connectTimeout(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .readTimeout(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
-                .build();
-    }
-
-    @PreDestroy
-    void close() {
-        if (this.client != null) {
-            this.client.close();
-        }
-    }
-
     /**
-     * Returns the public IP address of this host, querying remote services if the cache is stale.
+     * Returns the public IPv4 address of this host, querying remote services if the cache is stale.
      *
-     * @return the discovered IP address, or {@link Optional#empty()} when all services are
+     * @return the discovered IPv4 address, or {@link Optional#empty()} when all services are
      *     unreachable
      */
     public Optional<String> discover() {
@@ -100,28 +96,33 @@ public class PublicIpDiscoveryService {
     }
 
     private Optional<String> queryDiscoveryServices() {
-        for (String url : DISCOVERY_URLS) {
-            Optional<String> ip = queryService(url);
+        Client client = this.clientFactory.get();
 
-            if (ip.isPresent()) {
-                this.cachedIp.set(ip.get());
-                this.cacheExpiry = Instant.now().plus(Duration.ofHours(CACHE_HOURS));
-                return ip;
+        try {
+            for (URI url : DISCOVERY_URLS) {
+                Optional<String> ip = queryService(client, url);
+
+                if (ip.isPresent()) {
+                    this.cachedIp.set(ip.get());
+                    this.cacheExpiry = Instant.now().plus(Duration.ofHours(CACHE_HOURS));
+                    return ip;
+                }
             }
+        } finally {
+            client.close();
         }
 
         return Optional.empty();
     }
 
-    private Optional<String> queryService(String url) {
+    private Optional<String> queryService(Client client, URI url) {
         try {
-            String body = this.client
-                    .target(url)
+            String body = client.target(url)
                     .request(MediaType.TEXT_PLAIN_TYPE)
                     .get(String.class)
                     .strip();
 
-            if (!isValidIpAddress(body)) {
+            if (!isValidPublicIpv4Address(body)) {
                 LOGGER.log(System.Logger.Level.DEBUG, "Unexpected response from {0}: {1}", url, body);
                 return Optional.empty();
             }
@@ -138,14 +139,21 @@ public class PublicIpDiscoveryService {
         }
     }
 
-    private static boolean isValidIpAddress(String candidate) {
-        if (candidate == null || candidate.isBlank() || candidate.length() > 45) {
+    /**
+     * Returns {@code true} only when {@code candidate} is a literal dotted-decimal IPv4 address.
+     *
+     * <p>Uses a round-trip check — {@link InetAddress#getHostAddress()} must equal the original
+     * input — to reject DNS hostnames that {@link InetAddress#getByName(String)} would otherwise
+     * silently resolve.
+     */
+    static boolean isValidPublicIpv4Address(String candidate) {
+        if (candidate == null || candidate.isBlank() || candidate.length() > 15) {
             return false;
         }
 
         try {
-            InetAddress.getByName(candidate);
-            return true;
+            InetAddress addr = InetAddress.getByName(candidate);
+            return addr instanceof Inet4Address && addr.getHostAddress().equals(candidate);
         } catch (UnknownHostException unknownHostException) {
             return false;
         }

--- a/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/PublicIpDiscoveryService.java
+++ b/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/PublicIpDiscoveryService.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.core.sip;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.PostConstruct;
+import javax.annotation.PreDestroy;
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Discovers the public IPv4 address of this host by querying well-known plain-text IP-echo services.
+ *
+ * <p>Services are tried in order; the first successful, valid response is used.
+ * The result is cached for {@value #CACHE_HOURS} hour so that repeated calls during a registration
+ * cycle do not generate unnecessary HTTP traffic.
+ *
+ * <p>Each HTTP request times out after {@value #REQUEST_TIMEOUT_SECONDS} seconds.
+ * A failed request is logged at DEBUG level and the next service is tried.
+ * When all services fail, {@link Optional#empty()} is returned; the caller is responsible for
+ * falling back to a locally detected address.
+ *
+ * <h2>Services queried (in order)</h2>
+ *
+ * <ol>
+ *   <li>{@code https://ident.me} — plain text, IPv4 or IPv6</li>
+ *   <li>{@code https://api.ipify.org} — plain text, IPv4 only</li>
+ *   <li>{@code https://checkip.amazonaws.com} — plain text, IPv4 only</li>
+ * </ol>
+ */
+@ApplicationScoped
+public class PublicIpDiscoveryService {
+
+    private static final System.Logger LOGGER = System.getLogger(PublicIpDiscoveryService.class.getName());
+
+    static final List<String> DISCOVERY_URLS =
+            List.of("https://ident.me", "https://api.ipify.org", "https://checkip.amazonaws.com");
+
+    private static final int CACHE_HOURS = 1;
+    private static final long REQUEST_TIMEOUT_SECONDS = 2L;
+
+    /** The JAX-RS client; created in {@link #init()} and closed in {@link #close()}. */
+    Client client;
+
+    private final AtomicReference<String> cachedIp = new AtomicReference<>();
+    private volatile Instant cacheExpiry = Instant.MIN;
+
+    /** CDI no-args constructor. */
+    public PublicIpDiscoveryService() {}
+
+    @PostConstruct
+    void init() {
+        this.client = ClientBuilder.newBuilder()
+                .connectTimeout(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .readTimeout(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+                .build();
+    }
+
+    @PreDestroy
+    void close() {
+        if (this.client != null) {
+            this.client.close();
+        }
+    }
+
+    /**
+     * Returns the public IP address of this host, querying remote services if the cache is stale.
+     *
+     * @return the discovered IP address, or {@link Optional#empty()} when all services are
+     *     unreachable
+     */
+    public Optional<String> discover() {
+        String cached = this.cachedIp.get();
+
+        if (cached != null && Instant.now().isBefore(this.cacheExpiry)) {
+            return Optional.of(cached);
+        }
+
+        return queryDiscoveryServices();
+    }
+
+    private Optional<String> queryDiscoveryServices() {
+        for (String url : DISCOVERY_URLS) {
+            Optional<String> ip = queryService(url);
+
+            if (ip.isPresent()) {
+                this.cachedIp.set(ip.get());
+                this.cacheExpiry = Instant.now().plus(Duration.ofHours(CACHE_HOURS));
+                return ip;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<String> queryService(String url) {
+        try {
+            String body = this.client
+                    .target(url)
+                    .request(MediaType.TEXT_PLAIN_TYPE)
+                    .get(String.class)
+                    .strip();
+
+            if (!isValidIpAddress(body)) {
+                LOGGER.log(System.Logger.Level.DEBUG, "Unexpected response from {0}: {1}", url, body);
+                return Optional.empty();
+            }
+
+            LOGGER.log(System.Logger.Level.INFO, "Discovered public IP {0} via {1}", body, url);
+            return Optional.of(body);
+        } catch (ProcessingException processingException) {
+            LOGGER.log(
+                    System.Logger.Level.DEBUG,
+                    "Failed to query public IP from {0}: {1}",
+                    url,
+                    processingException.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    private static boolean isValidIpAddress(String candidate) {
+        if (candidate == null || candidate.isBlank() || candidate.length() > 45) {
+            return false;
+        }
+
+        try {
+            InetAddress.getByName(candidate);
+            return true;
+        } catch (UnknownHostException unknownHostException) {
+            return false;
+        }
+    }
+}

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -27,6 +27,11 @@ module de.bmarwell.proximo.pitido.core {
     // JDK platform modules
     requires java.naming; // javax.naming.* — JNDI SRV DNS lookup (package-private use only)
 
+    // JAX-RS 2.1 client API — provided at runtime by Liberty's jaxrsClient feature.
+    // javax.ws.rs-api declares "requires transitive java.xml.bind"; jaxb-api on the
+    // module path satisfies that at compile time; Liberty's jaxb feature covers runtime.
+    requires java.ws.rs;
+
     // MicroProfile Config — provided by Liberty; annotation-only use (@ConfigProperty)
     requires static microprofile.config.api;
 

--- a/core/src/test/java/de/bmarwell/proximo/pitido/core/sip/PublicIpDiscoveryServiceTest.java
+++ b/core/src/test/java/de/bmarwell/proximo/pitido/core/sip/PublicIpDiscoveryServiceTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.URI;
 import java.util.Optional;
 import javax.ws.rs.ProcessingException;
 import javax.ws.rs.client.Client;
@@ -30,7 +31,6 @@ import javax.ws.rs.core.MediaType;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -46,18 +46,24 @@ class PublicIpDiscoveryServiceTest {
     @Mock
     Invocation.Builder requestBuilder;
 
-    @InjectMocks
     PublicIpDiscoveryService discoveryService;
 
     @BeforeEach
-    void wireClientChain() {
-        when(this.client.target(any(String.class))).thenReturn(this.webTarget);
+    void setUp() {
+        this.discoveryService = new PublicIpDiscoveryService();
+        this.discoveryService.clientFactory = () -> this.client;
+    }
+
+    /** Stubs the JAX-RS fluent chain for tests that actually invoke {@link PublicIpDiscoveryService#discover()}. */
+    private void wireClientChain() {
+        when(this.client.target(any(URI.class))).thenReturn(this.webTarget);
         when(this.webTarget.request(any(MediaType.class))).thenReturn(this.requestBuilder);
     }
 
     @Test
     void discover_firstServiceRespondsWithValidIp_returnsThatIp() {
         // given
+        wireClientChain();
         when(this.requestBuilder.get(String.class)).thenReturn("1.2.3.4");
 
         // when
@@ -72,6 +78,7 @@ class PublicIpDiscoveryServiceTest {
     @Test
     void discover_firstServiceFails_triesNextAndReturnsItsIp() {
         // given
+        wireClientChain();
         when(this.requestBuilder.get(String.class))
                 .thenThrow(new ProcessingException("connection refused"))
                 .thenReturn("5.6.7.8");
@@ -87,6 +94,7 @@ class PublicIpDiscoveryServiceTest {
     @Test
     void discover_allServicesFail_returnsEmpty() {
         // given
+        wireClientChain();
         when(this.requestBuilder.get(String.class)).thenThrow(new ProcessingException("no route to host"));
 
         // when
@@ -99,6 +107,7 @@ class PublicIpDiscoveryServiceTest {
     @Test
     void discover_serviceReturnsInvalidBody_skipsToNextService() {
         // given
+        wireClientChain();
         when(this.requestBuilder.get(String.class))
                 .thenReturn("not-an-ip-address")
                 .thenReturn("9.10.11.12");
@@ -114,6 +123,7 @@ class PublicIpDiscoveryServiceTest {
     @Test
     void discover_secondCallWithinCacheWindow_doesNotQueryRemoteServices() {
         // given
+        wireClientChain();
         when(this.requestBuilder.get(String.class)).thenReturn("1.2.3.4");
         this.discoveryService.discover();
 
@@ -123,12 +133,13 @@ class PublicIpDiscoveryServiceTest {
         // then
         assertTrue(cached.isPresent());
         assertEquals("1.2.3.4", cached.get());
-        verify(this.client, times(1)).target(any(String.class));
+        verify(this.client, times(1)).target(any(URI.class));
     }
 
     @Test
     void discover_responseWithTrailingNewline_isStrippedAndAccepted() {
         // given
+        wireClientChain();
         when(this.requestBuilder.get(String.class)).thenReturn("203.0.113.1\n");
 
         // when
@@ -142,6 +153,7 @@ class PublicIpDiscoveryServiceTest {
     @Test
     void discover_firstServiceSucceeds_doesNotQueryFurtherServices() {
         // given
+        wireClientChain();
         when(this.requestBuilder.get(String.class)).thenReturn("1.2.3.4");
 
         // when
@@ -150,5 +162,23 @@ class PublicIpDiscoveryServiceTest {
         // then
         verify(this.client, never()).target(PublicIpDiscoveryService.DISCOVERY_URLS.get(1));
         verify(this.client, never()).target(PublicIpDiscoveryService.DISCOVERY_URLS.get(2));
+    }
+
+    @Test
+    void isValidPublicIpv4Address_rejectsIpv6Address() {
+        // given / when / then
+        assertFalse(PublicIpDiscoveryService.isValidPublicIpv4Address("2001:db8::1"));
+    }
+
+    @Test
+    void isValidPublicIpv4Address_rejectsHostname() {
+        // given / when / then
+        assertFalse(PublicIpDiscoveryService.isValidPublicIpv4Address("example.com"));
+    }
+
+    @Test
+    void isValidPublicIpv4Address_acceptsLiteralIpv4() {
+        // given / when / then
+        assertTrue(PublicIpDiscoveryService.isValidPublicIpv4Address("203.0.113.1"));
     }
 }

--- a/core/src/test/java/de/bmarwell/proximo/pitido/core/sip/PublicIpDiscoveryServiceTest.java
+++ b/core/src/test/java/de/bmarwell/proximo/pitido/core/sip/PublicIpDiscoveryServiceTest.java
@@ -1,0 +1,154 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.core.sip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PublicIpDiscoveryServiceTest {
+
+    @Mock
+    Client client;
+
+    @Mock
+    WebTarget webTarget;
+
+    @Mock
+    Invocation.Builder requestBuilder;
+
+    @InjectMocks
+    PublicIpDiscoveryService discoveryService;
+
+    @BeforeEach
+    void wireClientChain() {
+        when(this.client.target(any(String.class))).thenReturn(this.webTarget);
+        when(this.webTarget.request(any(MediaType.class))).thenReturn(this.requestBuilder);
+    }
+
+    @Test
+    void discover_firstServiceRespondsWithValidIp_returnsThatIp() {
+        // given
+        when(this.requestBuilder.get(String.class)).thenReturn("1.2.3.4");
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals("1.2.3.4", result.get());
+        verify(this.client, times(1)).target(PublicIpDiscoveryService.DISCOVERY_URLS.getFirst());
+    }
+
+    @Test
+    void discover_firstServiceFails_triesNextAndReturnsItsIp() {
+        // given
+        when(this.requestBuilder.get(String.class))
+                .thenThrow(new ProcessingException("connection refused"))
+                .thenReturn("5.6.7.8");
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals("5.6.7.8", result.get());
+    }
+
+    @Test
+    void discover_allServicesFail_returnsEmpty() {
+        // given
+        when(this.requestBuilder.get(String.class)).thenThrow(new ProcessingException("no route to host"));
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void discover_serviceReturnsInvalidBody_skipsToNextService() {
+        // given
+        when(this.requestBuilder.get(String.class))
+                .thenReturn("not-an-ip-address")
+                .thenReturn("9.10.11.12");
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals("9.10.11.12", result.get());
+    }
+
+    @Test
+    void discover_secondCallWithinCacheWindow_doesNotQueryRemoteServices() {
+        // given
+        when(this.requestBuilder.get(String.class)).thenReturn("1.2.3.4");
+        this.discoveryService.discover();
+
+        // when
+        Optional<String> cached = this.discoveryService.discover();
+
+        // then
+        assertTrue(cached.isPresent());
+        assertEquals("1.2.3.4", cached.get());
+        verify(this.client, times(1)).target(any(String.class));
+    }
+
+    @Test
+    void discover_responseWithTrailingNewline_isStrippedAndAccepted() {
+        // given
+        when(this.requestBuilder.get(String.class)).thenReturn("203.0.113.1\n");
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals("203.0.113.1", result.get());
+    }
+
+    @Test
+    void discover_firstServiceSucceeds_doesNotQueryFurtherServices() {
+        // given
+        when(this.requestBuilder.get(String.class)).thenReturn("1.2.3.4");
+
+        // when
+        this.discoveryService.discover();
+
+        // then
+        verify(this.client, never()).target(PublicIpDiscoveryService.DISCOVERY_URLS.get(1));
+        verify(this.client, never()).target(PublicIpDiscoveryService.DISCOVERY_URLS.get(2));
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,35 @@
         <scope>provided</scope>
       </dependency>
 
+      <!-- JAX-RS 2.1 client API — provided at runtime by Liberty's jaxrsClient feature -->
+      <dependency>
+        <groupId>javax.ws.rs</groupId>
+        <artifactId>javax.ws.rs-api</artifactId>
+        <version>2.1.1</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <!--
+        JAXB API — provided at runtime by Liberty's jaxb-2.2 feature (included in javaee-8.0).
+        Required at compile time because javax.ws.rs-api:2.1.1 declares
+        "requires transitive java.xml.bind" in its module-info, so javac must be able
+        to resolve the java.xml.bind module on the module path.
+      -->
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.1</version>
+        <scope>provided</scope>
+      </dependency>
+
+      <!-- Apache CXF JAX-RS client — test-time ClientBuilder SPI implementation -->
+      <dependency>
+        <groupId>org.apache.cxf</groupId>
+        <artifactId>cxf-rt-rs-client</artifactId>
+        <version>3.6.5</version>
+        <scope>test</scope>
+      </dependency>
+
       <!-- build dependencies -->
       <dependency>
         <groupId>com.palantir.javaformat</groupId>

--- a/war/src/main/liberty/config/server.xml
+++ b/war/src/main/liberty/config/server.xml
@@ -7,6 +7,8 @@
     <feature>servlet</feature>
     <feature>cdi</feature>
     <feature>concurrent</feature>
+    <feature>jaxrsClient</feature>
+    <feature>jaxb</feature>
 
     <platform>microProfile-4.1</platform>
     <feature>mpConfig</feature>


### PR DESCRIPTION
Closes #24

## What

Adds `PublicIpDiscoveryService` — an `@ApplicationScoped` CDI bean that queries plain-text IP-echo services to determine the public IP for the SIP `Contact` header, using the JAX-RS 2.1 `Client` API.

## Why JAX-RS (not `java.net.http`)

A container application should use container-managed resources.
Liberty's `jaxrsClient` feature provides a managed `ClientBuilder` SPI at runtime.

## The JAXB compile-time issue (and fix)

`javax.ws.rs-api:2.1.1` declares `requires transitive java.xml.bind` in its `module-info.class`.
Java 17+ removed `java.xml.bind` from the JDK, so javac cannot resolve it from the JDK module path alone.

Fix: add `javax.xml.bind:jaxb-api:2.3.1` as `provided` scope — it puts the `java.xml.bind` module on the compile-time module path.
At runtime, Liberty's `jaxb` feature (added to `server.xml`) provides it.

## Liberty features added (versionless — pinned by `javaee-8.0` platform)

- `jaxrsClient` — JAX-RS 2.1 client API + managed `ClientBuilder`
- `jaxb` — Java XML Bindings; satisfies the runtime `java.xml.bind` requirement

## Resolution order in `LocalSipHostProvider.get()`

1. `SIP_PUBLIC_HOST` / `sip.public.host` — explicit operator override, no network call
2. `PublicIpDiscoveryService.discover()` — when `sip.registration.enabled=true` (default)
3. First non-loopback IPv4 from local network interfaces — fallback with WARNING log

## Details

- Services tried in order: `ident.me`, `api.ipify.org`, `checkip.amazonaws.com`
- 2-second connect + read timeout per request
- 1-hour in-memory cache (`AtomicReference` + `volatile Instant`)
- Response validated via `InetAddress.getByName()` before use
- 7 unit tests: first-wins, fallback, all-fail, invalid body, caching, trailing newline, no-extra-calls