### PR TITLE
fix(docker,codecs): install vo-amrwbenc in Docker; guard AMR-WB forCall()

### DIFF
--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
@@ -249,10 +249,16 @@ public final class AmrWbRtpCodec extends NativeRtpCodec {
      * automatically, and the segment becomes invalid so that any attempt to encode after close
      * throws {@link IllegalStateException} rather than crashing the JVM.
      *
-     * @throws IllegalStateException if {@code E_IF_init} returns a null pointer
+     * @throws IllegalStateException if the codec is not available (library not loaded),
+     *                               or if {@code E_IF_init} returns a null pointer
      */
     @Override
     public RtpCodec forCall() {
+        if (!this.available) {
+            throw new IllegalStateException(
+                    "AMR-WB codec is not available — libvo-amrwbenc was not loaded; check probe() logs");
+        }
+
         MemorySegment rawStatePtr = invokeInit();
 
         if (rawStatePtr.address() == 0L) {

--- a/war/src/main/docker/Dockerfile
+++ b/war/src/main/docker/Dockerfile
@@ -1,12 +1,15 @@
 FROM icr.io/appcafe/open-liberty:kernel-slim-java25-openj9-ubi-minimal
 
 # Install native libraries required for audio codecs:
-#   opus      → libopus.so.0  (OGG/Opus audio decoding via FFM)
-#   spandsp   → libspandsp.so.2  (G.722 wideband encoding via FFM)
-# spandsp is in EPEL 9, not in standard UBI repos — add EPEL first.
+#   opus           → libopus.so.0      (OGG/Opus audio decoding via FFM)
+#   spandsp        → libspandsp.so.2   (G.722 wideband encoding via FFM)
+#   vo-amrwbenc    → libvo-amrwbenc.so.0  (AMR-WB encoding via FFM for VoLTE callers)
+# spandsp and vo-amrwbenc are not in standard UBI repos.
+# spandsp is in EPEL 9; vo-amrwbenc is in RPM Fusion free — add both repos first.
 USER root
 RUN rpm -i https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
-    && microdnf install -y --nodocs opus spandsp \
+    && rpm -i https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm \
+    && microdnf install -y --nodocs opus spandsp vo-amrwbenc \
     && microdnf clean all
 USER 1001
 

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -198,6 +198,13 @@ public class SdpNegotiator {
                 .min(Comparator.comparingInt(RtpCodec::preference))
                 .orElse(PcmaRtpCodec.INSTANCE);
 
+        LOGGER.log(
+                System.Logger.Level.DEBUG,
+                "Codec selected: {0} (PT {1}) from offered payload types {2}",
+                descriptor.sdpName(),
+                descriptor.payloadType(),
+                offeredPayloadTypes);
+
         return descriptor.forCall();
     }
 


### PR DESCRIPTION
## Problem

After merging AMR-WB support, the Docker container logs:
`libvo-amrwbenc not found — AMR-WB RTP codec disabled`

The library was missing from the image, and there was no explicit guard preventing accidental use.

## Fixes

### 1. Install `vo-amrwbenc` in Docker

Adds RPM Fusion free repo alongside the existing EPEL repo, then installs `vo-amrwbenc` (which provides `libvo-amrwbenc.so.0`).
The codec now loads successfully at container startup.

### 2. Defensive guard in `AmrWbRtpCodec.forCall()`

Throws `IllegalStateException` immediately if the native library was not loaded, rather than calling `E_IF_init()` on a null handle.
`SdpNegotiator.selectCodec()` already filters by `isAvailable()`, so this guard is an explicit safety net for any future call path.

### 3. DEBUG log in `SdpNegotiator.selectCodec()`

Records the selected codec name, payload type, and the full set of offered payload types, making negotiation decisions visible in debug logs.