### PR TITLE
refactor: overhaul logging across all call-lifecycle classes

### DIFF
--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/SipTimeServlet.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/SipTimeServlet.java
@@ -79,7 +79,7 @@ public class SipTimeServlet extends SipServlet implements Serializable {
     protected void doResponse(SipServletResponse response) throws ServletException, IOException {
         int status = response.getStatus();
         String method = response.getMethod();
-        LOGGER.log(System.Logger.Level.INFO, "SIP response [{0}] for method [{1}]", status, method);
+        LOGGER.log(System.Logger.Level.DEBUG, "SIP response [{0}] for method [{1}]", status, method);
 
         if (!"REGISTER".equals(method)) {
             return;
@@ -99,8 +99,6 @@ public class SipTimeServlet extends SipServlet implements Serializable {
                     grantedExpires);
             return;
         }
-
-        LOGGER.log(System.Logger.Level.INFO, "SIP registration completed unsuccessfully (status [{0}])", status);
 
         LOGGER.log(System.Logger.Level.WARNING, "Unexpected REGISTER response [{0}]: {1}", status, response);
     }

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/AnnouncementLoop.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/AnnouncementLoop.java
@@ -65,24 +65,12 @@ public class AnnouncementLoop {
      * {@link #CALL_MAX_DURATION} elapses.
      * On exit, removes the call from session state and closes the media socket.
      */
-    void play(
-            SipSession session,
-            AudioPlayer player,
-            LanguageFactory factory,
-            String sessionId,
-            CallMedia media,
-            String callerIdentitySummary) {
+    void play(SipSession session, AudioPlayer player, LanguageFactory factory, String sessionId, CallMedia media) {
         LOGGER.log(
-                System.Logger.Level.INFO,
+                System.Logger.Level.DEBUG,
                 "{0}Announcement loop starting — language [{1}]",
                 SipCallHeaders.callPrefix(sessionId),
                 factory.displayName());
-        LOGGER.log(
-                System.Logger.Level.DEBUG,
-                "{0}Announcement loop context: codec=[{1}], caller={2}",
-                SipCallHeaders.callPrefix(sessionId),
-                media.codec().sdpName(),
-                callerIdentitySummary);
 
         Instant deadline = Instant.now().plus(CALL_MAX_DURATION);
 

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
@@ -108,10 +108,11 @@ public class CallAcceptor {
         }
 
         LOGGER.log(
-                System.Logger.Level.DEBUG,
-                "{0}Incoming call from [{1}]",
+                System.Logger.Level.INFO,
+                "{0}INVITE from [{1}] to [{2}]",
                 SipCallHeaders.callPrefix(callId),
-                req.getFrom());
+                req.getFrom(),
+                req.getTo());
 
         if (this.sipCallBlacklist.isBlacklisted(req)) {
             LOGGER.log(
@@ -171,6 +172,11 @@ public class CallAcceptor {
 
         Instant startTime = Instant.now();
         String callerIdentitySummary = SipCallHeaders.buildCallerIdentitySummary(req);
+        LOGGER.log(
+                System.Logger.Level.DEBUG,
+                "{0}Caller identity: {1}",
+                SipCallHeaders.callPrefix(sessionId),
+                callerIdentitySummary);
         LinkedHashMap<Integer, LanguageFactory> singleMenu = new LinkedHashMap<>();
         singleMenu.put(1, factory);
 
@@ -183,7 +189,7 @@ public class CallAcceptor {
                 return;
             }
 
-            this.announcementLoop.play(session, player, factory, sessionId, media, callerIdentitySummary);
+            this.announcementLoop.play(session, player, factory, sessionId, media);
         });
 
         this.callSessionManager.register(
@@ -208,9 +214,14 @@ public class CallAcceptor {
         AudioPlayer player = new RtpAudioPlayer(media, this.pcmDecoderFactory);
         Instant startTime = Instant.now();
         String callerIdentitySummary = SipCallHeaders.buildCallerIdentitySummary(req);
+        LOGGER.log(
+                System.Logger.Level.DEBUG,
+                "{0}Caller identity: {1}",
+                SipCallHeaders.callPrefix(sessionId),
+                callerIdentitySummary);
 
-        Future<?> callFuture = this.managedExecutorService.submit(
-                () -> this.menuRunner.run(session, player, menu, sessionId, media, callerIdentitySummary));
+        Future<?> callFuture =
+                this.managedExecutorService.submit(() -> this.menuRunner.run(session, player, menu, sessionId, media));
         Future<?> receiverFuture = this.dtmfDispatcher.startReceiver(media, sessionId);
 
         this.callSessionManager.register(
@@ -226,18 +237,14 @@ public class CallAcceptor {
      */
     private CallMedia negotiateAndRespond(SipServletRequest req, String sessionId, String description)
             throws IOException {
-        LOGGER.log(
-                System.Logger.Level.DEBUG,
-                "{0}Accepting call from [{1}]",
-                SipCallHeaders.callPrefix(sessionId),
-                req.getFrom());
         CallMedia media = this.sdpNegotiator.negotiate(req);
         LOGGER.log(
                 System.Logger.Level.INFO,
-                "{0}Call accepted — {1}, codec [{2}]",
+                "{0}200 OK — {1}, codec [{2}], remote RTP [{3}]",
                 SipCallHeaders.callPrefix(sessionId),
                 description,
-                media.codec().sdpName());
+                media.codec().sdpName(),
+                media.remoteRtp());
         SipServletResponse response = req.createResponse(SipServletResponse.SC_OK);
         response.setContent(media.sdpAnswer().getBytes(StandardCharsets.UTF_8), "application/sdp");
         response.send();

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
@@ -91,13 +91,21 @@ public class CallSessionManager {
 
         callState.callFuture().cancel(true);
         callState.receiverFuture().cancel(true);
+        String codecName = callState.media().codec().sdpName();
         closeMedia(callState.media());
         Duration callDuration = Duration.between(callState.startTime(), Instant.now());
         LOGGER.log(
                 System.Logger.Level.INFO,
-                "{0}Call ended — duration {1}s",
+                "{0}Call ended — from=[{1}], codec=[{2}], duration={3}s",
                 SipCallHeaders.callPrefix(sessionId),
+                req.getFrom(),
+                codecName,
                 callDuration.toSeconds());
+        LOGGER.log(
+                System.Logger.Level.DEBUG,
+                "{0}Caller identity: {1}",
+                SipCallHeaders.callPrefix(sessionId),
+                callState.callerIdentitySummary());
         this.pendingSelections.remove(sessionId);
         req.createResponse(SipServletResponse.SC_OK).send();
     }
@@ -128,7 +136,7 @@ public class CallSessionManager {
         try {
             media.codec().close();
         } catch (Exception closeException) {
-            LOGGER.log(System.Logger.Level.DEBUG, "Error closing codec after call", closeException);
+            LOGGER.log(System.Logger.Level.WARNING, "Error closing codec after call", closeException);
         }
     }
 

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/MenuRunner.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/MenuRunner.java
@@ -62,8 +62,7 @@ public class MenuRunner {
             AudioPlayer player,
             SequencedMap<Integer, LanguageFactory> menu,
             String sessionId,
-            CallMedia media,
-            String callerIdentitySummary) {
+            CallMedia media) {
         try {
             Thread.sleep(5_000);
             runMenuLoop(player, menu, sessionId);
@@ -73,7 +72,7 @@ public class MenuRunner {
             LanguageFactory chosen = this.callSessionManager.takePendingSelection(sessionId);
 
             if (chosen != null) {
-                this.announcementLoop.play(session, player, chosen, sessionId, media, callerIdentitySummary);
+                this.announcementLoop.play(session, player, chosen, sessionId, media);
             } else {
                 LOGGER.log(
                         System.Logger.Level.INFO,

--- a/war/src/main/liberty/config/server.xml
+++ b/war/src/main/liberty/config/server.xml
@@ -45,23 +45,23 @@
   <!--
     Default runtime logging profile.
     Liberty base level stays at AUDIT for framework noise control.
-    SipCallHandler runs at DEBUG by default to inspect caller identity headers, codec choices, DTMF input, and call lifecycle transitions.
-    SipRegistrationListener runs at INFO by default to track REGISTER/auth progress without per-attempt DEBUG noise.
+    All classes under de.bmarwell.proximo.pitido.* are set to fine (DEBUG) so that
+    technical details are captured in trace.log without appearing in docker compose logs.
+    RtpAudioPlayer and RtpDtmfReceiver are set to finest because their per-packet logging
+    is extremely verbose and is only useful for RTP-level diagnosis.
 
     Optional trace selectors to enable when diagnosing specific problems:
-    - de.bmarwell.proximo.pitido.war.media.SdpNegotiator=debug
+    - de.bmarwell.proximo.pitido.war.media.SdpNegotiator=finest
       Shows parsed SDP offer details, selected RTP endpoint data, and codec matching.
-    - de.bmarwell.proximo.pitido.war.media.RtpAudioPlayer=debug
-      Shows RTP packetisationz/send-path details and is usually too verbose for normal operation.
-    - de.bmarwell.proximo.pitido.codecs.input.*=debug
+    - de.bmarwell.proximo.pitido.codecs.input.*=finest
       Shows native decoder and mixer capability probes (opus/soxr) and fallback decisions.
-    - de.bmarwell.proximo.pitido.codecs.sip.*=debug
+    - de.bmarwell.proximo.pitido.codecs.sip.*=finest
       Shows SIP codec availability probes (for example, G.722 native encoder readiness).
   -->
   <logging
     consoleLogLevel="INFO"
     consoleFormat="TBASIC"
-    traceSpecification="*=audit:de.bmarwell.proximo.pitido.war.listener.SipCallHandler=finest:de.bmarwell.proximo.pitido.war.listener.SipRegistrationListener=fine:de.bmarwell.proximo.pitido.war.listener.LanguageInfoListener=fine:de.bmarwell.proximo.pitido.war.media.RtpDtmfReceiver=finest"
+    traceSpecification="*=audit:de.bmarwell.proximo.pitido.*=fine:de.bmarwell.proximo.pitido.war.media.RtpAudioPlayer=finest:de.bmarwell.proximo.pitido.war.media.RtpDtmfReceiver=finest"
     hideMessage="CWOWB1009W,CWSCT0017E"
     isoDateFormat="true"
   />

--- a/war/src/main/liberty/config/server.xml
+++ b/war/src/main/liberty/config/server.xml
@@ -45,10 +45,9 @@
   <!--
     Default runtime logging profile.
     Liberty base level stays at AUDIT for framework noise control.
-    All classes under de.bmarwell.proximo.pitido.* are set to fine (DEBUG) so that
-    technical details are captured in trace.log without appearing in docker compose logs.
-    RtpAudioPlayer and RtpDtmfReceiver are set to finest because their per-packet logging
-    is extremely verbose and is only useful for RTP-level diagnosis.
+    All classes under de.bmarwell.proximo.pitido.* are set to fine (DEBUG) so that technical details are captured in trace.log without appearing in docker compose logs.
+    This replaces the previous class-by-class list (SipCallHandler, SipRegistrationListener, LanguageInfoListener): SipCallHandler is a routing-only delegate with no log statements of its own; the package wildcard covers all actual logging classes without needing to enumerate them individually.
+    RtpAudioPlayer and RtpDtmfReceiver are set to finest because their per-packet logging is extremely verbose and is only useful for RTP-level diagnosis.
 
     Optional trace selectors to enable when diagnosing specific problems:
     - de.bmarwell.proximo.pitido.war.media.SdpNegotiator=finest


### PR DESCRIPTION
INFO level now carries only business events visible in docker compose logs:
- INVITE from [from] to [to]
- 200 OK — language [X], codec [Y], remote RTP [host:port]
- Call ended — from=[from], codec=[Y], duration=Ns
- Registration success/failure, blacklist rejections, menu expiry

DEBUG level captures technical detail in trace.log only:
- Caller identity summary (full SIP headers)
- Announcement loop startup, DTMF, RTP-level events
- SIP response round-trips (per-response logging demoted from INFO)

Other fixes:
- Remove redundant 'Accepting call from' DEBUG in negotiateAndRespond
- Remove 'Announcement loop context' DEBUG (now logged in CallAcceptor)
- Remove callerIdentitySummary parameter from AnnouncementLoop.play() and MenuRunner.run()
- Demote 'Announcement loop starting' from INFO to DEBUG
- Enrich 'Call ended' INFO with from-address and codec name
- Add callerIdentitySummary DEBUG in handleBye for post-call diagnosis
- Elevate codec close exception from DEBUG to WARNING
- Remove redundant 'SIP registration completed unsuccessfully' INFO before WARNING
- Fix stale traceSpecification: replace non-existent SipCallHandler with package wildcard de.bmarwell.proximo.pitido.*=fine; add RtpAudioPlayer=finest override