### PR TITLE
fix: preserve interrupt flag in MenuRunner on cancellation

### DIFF
--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/MenuRunner.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/MenuRunner.java
@@ -67,7 +67,7 @@ public class MenuRunner {
             Thread.sleep(5_000);
             runMenuLoop(player, menu, sessionId);
         } catch (InterruptedException interruptedException) {
-            Thread.interrupted();
+            Thread.currentThread().interrupt();
         } finally {
             LanguageFactory chosen = this.callSessionManager.takePendingSelection(sessionId);
 


### PR DESCRIPTION
Closes #54

## Problem

`MenuRunner.run()` was calling `Thread.interrupted()` in its `InterruptedException` catch block.
`Thread.interrupted()` clears the interrupt flag without restoring it, so when `Future.cancel(true)` interrupted the menu loop the flag was silently consumed and no subsequent interruptible operation could observe the cancellation.

## Fix

Replace with `Thread.currentThread().interrupt()` to restore the flag after catching the exception, matching the pattern already used correctly in `AnnouncementLoop`.