### PR TITLE
fix(#57): match SDP codecs by rtpmap name+rate, not static payload type

### DIFF
--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
@@ -20,6 +20,7 @@ import java.lang.foreign.MemorySegment;
 import java.lang.foreign.SymbolLookup;
 import java.lang.foreign.ValueLayout;
 import java.lang.invoke.MethodHandle;
+import java.util.Arrays;
 import javax.annotation.PostConstruct;
 import javax.enterprise.context.ApplicationScoped;
 
@@ -313,16 +314,24 @@ public final class AmrWbRtpCodec extends NativeRtpCodec {
     }
 
     /**
-     * AMR-WB requires octet-aligned packetisation (RFC 4867 §4.4).
+     * This implementation requires octet-aligned packetisation (RFC 4867 §4.4).
      *
      * <p>Callers may advertise AMR-WB under multiple dynamic payload types: one for
      * bandwidth-efficient mode (no {@code octet-align=1} in fmtp) and one for octet-aligned mode.
      * This implementation only encodes octet-aligned frames, so only the payload type whose fmtp
      * declares {@code octet-align=1} is accepted.
+     *
+     * <p>Parameters are parsed as semicolon-separated {@code key=value} pairs per RFC 4867 §8.2,
+     * so values such as {@code octet-align=10} are not falsely matched.
      */
     @Override
     public boolean matchesFmtp(String offeredFmtp) {
-        return offeredFmtp.contains("octet-align=1");
+        return Arrays.stream(offeredFmtp.split(";")).map(String::strip).anyMatch(AmrWbRtpCodec::isOctetAlignParam);
+    }
+
+    private static boolean isOctetAlignParam(String param) {
+        String[] kv = param.split("=", 2);
+        return kv.length == 2 && "octet-align".equalsIgnoreCase(kv[0].strip()) && "1".equals(kv[1].strip());
     }
 
     /**

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
@@ -313,6 +313,19 @@ public final class AmrWbRtpCodec extends NativeRtpCodec {
     }
 
     /**
+     * AMR-WB requires octet-aligned packetisation (RFC 4867 §4.4).
+     *
+     * <p>Callers may advertise AMR-WB under multiple dynamic payload types: one for
+     * bandwidth-efficient mode (no {@code octet-align=1} in fmtp) and one for octet-aligned mode.
+     * This implementation only encodes octet-aligned frames, so only the payload type whose fmtp
+     * declares {@code octet-align=1} is accepted.
+     */
+    @Override
+    public boolean matchesFmtp(String offeredFmtp) {
+        return offeredFmtp.contains("octet-align=1");
+    }
+
+    /**
      * Encodes one frame of 320 mono PCM samples at 16 kHz to AMR-WB octet-aligned RTP payload.
      *
      * <p>The returned array contains the complete RFC 4867 §4.4 octet-aligned payload:

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/RtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/RtpCodec.java
@@ -148,6 +148,24 @@ public interface RtpCodec extends AutoCloseable {
     String fmtpParams();
 
     /**
+     * Returns {@code true} if the given {@code a=fmtp} parameter string from the SDP offer is
+     * compatible with this codec's packetisation requirements.
+     *
+     * <p>The default returns {@code true}, meaning the codec accepts any (or no) fmtp parameters.
+     * Codecs that have a mandatory packetisation mode — such as AMR-WB in octet-aligned mode —
+     * must override this method and reject offers that do not declare the required parameter.
+     *
+     * @param offeredFmtp the fmtp parameter string from the caller's SDP offer
+     *                    (the part after {@code "a=fmtp:<pt> "}), or an empty string if the
+     *                    caller did not include an {@code a=fmtp} line for this payload type
+     * @return {@code true} if the offer is compatible; {@code false} if the packetisation mode
+     *         is incompatible and this payload type must be skipped during negotiation
+     */
+    default boolean matchesFmtp(String offeredFmtp) {
+        return true;
+    }
+
+    /**
      * Releases any native resources held by this per-call codec instance.
      *
      * <p>Stateless codecs (e.g. PCMA) return {@code this} from {@link #forCall()} and must not

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/NegotiatedRtpCodec.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/NegotiatedRtpCodec.java
@@ -27,16 +27,11 @@ import java.io.IOException;
  * and the SDP answer use the same PT value the caller expects.
  *
  * <p>All methods other than {@link #payloadType()} delegate to the wrapped per-call codec instance.
+ *
+ * @param delegate               the per-call codec instance obtained from {@link RtpCodec#forCall()}
+ * @param negotiatedPayloadType  the payload type assigned by the caller in the SDP offer
  */
-class NegotiatedRtpCodec implements RtpCodec {
-
-    private final RtpCodec delegate;
-    private final int negotiatedPayloadType;
-
-    NegotiatedRtpCodec(RtpCodec delegate, int negotiatedPayloadType) {
-        this.delegate = delegate;
-        this.negotiatedPayloadType = negotiatedPayloadType;
-    }
+record NegotiatedRtpCodec(RtpCodec delegate, int negotiatedPayloadType) implements RtpCodec {
 
     /**
      * Returns the payload type assigned by the caller in the SDP offer's {@code a=rtpmap} line.

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/NegotiatedRtpCodec.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/NegotiatedRtpCodec.java
@@ -1,0 +1,114 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.war.media;
+
+import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
+import java.io.IOException;
+
+/**
+ * Wraps a per-call {@link RtpCodec} instance and overrides {@link #payloadType()} to return the
+ * payload type actually negotiated with the caller rather than the codec's static default.
+ *
+ * <p>VoLTE callers (e.g. Deutsche Telekom) assign dynamic payload types (96–127) per-call via
+ * {@code a=rtpmap} lines.
+ * The underlying codec (e.g. {@link de.bmarwell.proximo.pitido.codecs.sip.AmrWbRtpCodec}) carries a
+ * conventional default PT for identification purposes only.
+ * This wrapper carries the actual PT assigned by the caller so that outgoing RTP packet headers
+ * and the SDP answer use the same PT value the caller expects.
+ *
+ * <p>All methods other than {@link #payloadType()} delegate to the wrapped per-call codec instance.
+ */
+class NegotiatedRtpCodec implements RtpCodec {
+
+    private final RtpCodec delegate;
+    private final int negotiatedPayloadType;
+
+    NegotiatedRtpCodec(RtpCodec delegate, int negotiatedPayloadType) {
+        this.delegate = delegate;
+        this.negotiatedPayloadType = negotiatedPayloadType;
+    }
+
+    /**
+     * Returns the payload type assigned by the caller in the SDP offer's {@code a=rtpmap} line.
+     * This value is used in outgoing RTP packet headers and in the SDP answer.
+     */
+    @Override
+    public int payloadType() {
+        return this.negotiatedPayloadType;
+    }
+
+    @Override
+    public boolean isAvailable() {
+        return this.delegate.isAvailable();
+    }
+
+    @Override
+    public int preference() {
+        return this.delegate.preference();
+    }
+
+    @Override
+    public RtpCodec forCall() {
+        return new NegotiatedRtpCodec(this.delegate.forCall(), this.negotiatedPayloadType);
+    }
+
+    @Override
+    public int rtpClockRate() {
+        return this.delegate.rtpClockRate();
+    }
+
+    @Override
+    public int inputSampleRate() {
+        return this.delegate.inputSampleRate();
+    }
+
+    @Override
+    public int samplesPerFrame() {
+        return this.delegate.samplesPerFrame();
+    }
+
+    @Override
+    public int rtpTimestampIncrement() {
+        return this.delegate.rtpTimestampIncrement();
+    }
+
+    @Override
+    public byte[] encode(short[] pcmFrame) throws IOException {
+        return this.delegate.encode(pcmFrame);
+    }
+
+    @Override
+    public int sdpChannelCount() {
+        return this.delegate.sdpChannelCount();
+    }
+
+    @Override
+    public String sdpName() {
+        return this.delegate.sdpName();
+    }
+
+    @Override
+    public String fmtpParams() {
+        return this.delegate.fmtpParams();
+    }
+
+    @Override
+    public boolean matchesFmtp(String offeredFmtp) {
+        return this.delegate.matchesFmtp(offeredFmtp);
+    }
+
+    @Override
+    public void close() {
+        this.delegate.close();
+    }
+}

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -202,24 +203,28 @@ public class SdpNegotiator {
         Map<Integer, String> result = new LinkedHashMap<>();
 
         sdp.lines().filter(line -> line.startsWith("a=rtpmap:")).forEach(line -> {
-            // a=rtpmap:<pt> <name>/<rate>[/<channels>]
-            String rest = line.substring("a=rtpmap:".length()).strip();
-            int spacePos = rest.indexOf(' ');
+            try {
+                // a=rtpmap:<pt> <name>/<rate>[/<channels>]
+                String rest = line.substring("a=rtpmap:".length()).strip();
+                int spacePos = rest.indexOf(' ');
 
-            if (spacePos < 0) {
-                return;
+                if (spacePos < 0) {
+                    return;
+                }
+
+                int pt = Integer.parseInt(rest.substring(0, spacePos));
+                String encoding = rest.substring(spacePos + 1).strip();
+                String[] encodingParts = encoding.split("/");
+
+                if (encodingParts.length < 2) {
+                    return;
+                }
+
+                String codecKey = (encodingParts[0] + "/" + encodingParts[1]).toUpperCase(Locale.ROOT);
+                result.put(pt, codecKey);
+            } catch (NumberFormatException | IndexOutOfBoundsException ignored) {
+                // Skip malformed a=rtpmap lines; remaining codecs can still be matched.
             }
-
-            int pt = Integer.parseInt(rest.substring(0, spacePos));
-            String encoding = rest.substring(spacePos + 1).strip();
-            String[] encodingParts = encoding.split("/");
-
-            if (encodingParts.length < 2) {
-                return;
-            }
-
-            String codecKey = (encodingParts[0] + "/" + encodingParts[1]).toUpperCase();
-            result.put(pt, codecKey);
         });
 
         return result;
@@ -244,7 +249,15 @@ public class SdpNegotiator {
                 return;
             }
 
-            int pt = Integer.parseInt(rest.substring(0, spacePos));
+            final int pt;
+
+            try {
+                pt = Integer.parseInt(rest.substring(0, spacePos));
+            } catch (NumberFormatException ignored) {
+                // Skip malformed a=fmtp lines; this payload type simply has no fmtp params.
+                return;
+            }
+
             String params = rest.substring(spacePos + 1).strip();
             result.put(pt, params);
         });
@@ -334,12 +347,12 @@ public class SdpNegotiator {
      */
     private static Optional<Integer> negotiatedPt(
             RtpCodec codec, Set<Integer> offeredPts, Map<Integer, String> rtpmap, Map<Integer, String> fmtp) {
-        String codecKey = (codec.sdpName() + "/" + codec.rtpClockRate()).toUpperCase();
+        String codecKey = (codec.sdpName() + "/" + codec.rtpClockRate()).toUpperCase(Locale.ROOT);
 
         // Find the first offered PT whose rtpmap matches this codec and whose fmtp is compatible.
         Optional<Integer> fromRtpmap = rtpmap.entrySet().stream()
                 .filter(entry -> offeredPts.contains(entry.getKey()))
-                .filter(entry -> entry.getValue().equalsIgnoreCase(codecKey))
+                .filter(entry -> entry.getValue().equals(codecKey))
                 .filter(entry -> codec.matchesFmtp(fmtp.getOrDefault(entry.getKey(), "")))
                 .map(Map.Entry::getKey)
                 .findFirst();
@@ -348,9 +361,21 @@ public class SdpNegotiator {
             return fromRtpmap;
         }
 
-        // Fallback: static payload type (0–95), offered without an explicit rtpmap line.
-        if (offeredPts.contains(codec.payloadType()) && codec.matchesFmtp("")) {
-            return Optional.of(codec.payloadType());
+        int payloadType = codec.payloadType();
+
+        // Fallback: static payload type (0–95) offered without an explicit rtpmap line.
+        // Dynamic PTs (96–127) must always be declared via a=rtpmap; skip them here.
+        // Also skip if the rtpmap already maps this PT to a different codec.
+        if (payloadType > 95) {
+            return Optional.empty();
+        }
+
+        if (rtpmap.containsKey(payloadType)) {
+            return Optional.empty();
+        }
+
+        if (offeredPts.contains(payloadType) && codec.matchesFmtp("")) {
+            return Optional.of(payloadType);
         }
 
         return Optional.empty();

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -21,9 +21,13 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
@@ -83,7 +87,7 @@ public class SdpNegotiator {
         String remoteIp = parseConnectionIp(sdpOffer);
         int remotePort = parseAudioPort(sdpOffer);
         int telephoneEventPt = parseTelephoneEventPayloadType(sdpOffer);
-        RtpCodec codec = selectCodec(parseOfferedPayloadTypes(sdpOffer));
+        RtpCodec codec = selectCodec(sdpOffer);
 
         DatagramSocket localSocket = new DatagramSocket(0);
         int localPort = localSocket.getLocalPort();
@@ -185,27 +189,171 @@ public class SdpNegotiator {
     }
 
     /**
-     * Selects the best available codec from the CDI-injected {@link RtpCodec} beans.
-     * Filters by {@link RtpCodec#isAvailable()}, sorts by {@link RtpCodec#preference()}
-     * (lower = preferred), then picks the first whose payload type appears in the offer.
-     * Falls back to {@link PcmaRtpCodec#INSTANCE} if nothing matches.
-     * Calls {@link RtpCodec#forCall()} on the winner to obtain a per-call encoder instance.
+     * Parses {@code a=rtpmap} lines from the SDP offer into a map of payload type → codec key.
+     *
+     * <p>The codec key is {@code "<NAME>/<RATE>"} in upper case, e.g. {@code "AMR-WB/16000"}.
+     * Insertion order follows the document order of the {@code a=rtpmap} lines, which typically
+     * matches the preference order from the {@code m=audio} line.
+     *
+     * @param sdp the full SDP offer string
+     * @return a map from payload type to codec key; empty map if no {@code a=rtpmap} lines are present
      */
-    private RtpCodec selectCodec(Set<Integer> offeredPayloadTypes) {
-        RtpCodec descriptor = this.availableCodecs.stream()
-                .filter(RtpCodec::isAvailable)
-                .filter(codec -> offeredPayloadTypes.contains(codec.payloadType()))
-                .min(Comparator.comparingInt(RtpCodec::preference))
-                .orElse(PcmaRtpCodec.INSTANCE);
+    static Map<Integer, String> parseRtpmap(String sdp) {
+        Map<Integer, String> result = new LinkedHashMap<>();
+
+        sdp.lines().filter(line -> line.startsWith("a=rtpmap:")).forEach(line -> {
+            // a=rtpmap:<pt> <name>/<rate>[/<channels>]
+            String rest = line.substring("a=rtpmap:".length()).strip();
+            int spacePos = rest.indexOf(' ');
+
+            if (spacePos < 0) {
+                return;
+            }
+
+            int pt = Integer.parseInt(rest.substring(0, spacePos));
+            String encoding = rest.substring(spacePos + 1).strip();
+            String[] encodingParts = encoding.split("/");
+
+            if (encodingParts.length < 2) {
+                return;
+            }
+
+            String codecKey = (encodingParts[0] + "/" + encodingParts[1]).toUpperCase();
+            result.put(pt, codecKey);
+        });
+
+        return result;
+    }
+
+    /**
+     * Parses {@code a=fmtp} lines from the SDP offer into a map of payload type → fmtp parameters.
+     *
+     * @param sdp the full SDP offer string
+     * @return a map from payload type to fmtp parameter string (the part after the {@code "<pt> "});
+     *         empty map if no {@code a=fmtp} lines are present
+     */
+    static Map<Integer, String> parseFmtp(String sdp) {
+        Map<Integer, String> result = new LinkedHashMap<>();
+
+        sdp.lines().filter(line -> line.startsWith("a=fmtp:")).forEach(line -> {
+            // a=fmtp:<pt> <params>
+            String rest = line.substring("a=fmtp:".length()).strip();
+            int spacePos = rest.indexOf(' ');
+
+            if (spacePos < 0) {
+                return;
+            }
+
+            int pt = Integer.parseInt(rest.substring(0, spacePos));
+            String params = rest.substring(spacePos + 1).strip();
+            result.put(pt, params);
+        });
+
+        return result;
+    }
+
+    /**
+     * Selects the best available codec from the CDI-injected {@link RtpCodec} beans.
+     *
+     * <p>Filters by {@link RtpCodec#isAvailable()}, sorts by {@link RtpCodec#preference()}
+     * (lower = preferred), then matches each codec by name and clock rate against the
+     * {@code a=rtpmap} lines in the SDP offer.
+     * For codecs with dynamic payload types (96–127), the matching is done by codec key
+     * ({@code NAME/RATE}) rather than by static payload type number, because the caller
+     * assigns a fresh payload type per call.
+     * The payload type found in the offer is preserved in a {@link NegotiatedRtpCodec} wrapper
+     * so that outgoing RTP packet headers and the SDP answer use the correct value.
+     *
+     * <p>Falls back to the static payload type match for codecs whose payload type is in the
+     * static range (0–95) and which are offered without an explicit {@code a=rtpmap} line (e.g.
+     * PCMA at PT 8, which is sometimes omitted by legacy endpoints).
+     *
+     * <p>Falls back to {@link PcmaRtpCodec#INSTANCE} if no injected codec matches.
+     *
+     * @param sdpOffer the full SDP offer string from the INVITE body
+     * @return a per-call codec instance whose {@link RtpCodec#payloadType()} returns the PT
+     *         that was actually negotiated with the caller
+     */
+    private RtpCodec selectCodec(String sdpOffer) {
+        return selectCodec(this.availableCodecs.stream(), sdpOffer);
+    }
+
+    /**
+     * Selects the best codec from the given stream, matching against the SDP offer.
+     *
+     * <p>This static overload exists to allow unit testing without CDI injection.
+     *
+     * @param codecs   available codec descriptors, each an {@code @ApplicationScoped} CDI bean
+     * @param sdpOffer the full SDP offer string from the INVITE body
+     * @return a {@link NegotiatedRtpCodec} wrapping the selected per-call codec instance
+     */
+    static RtpCodec selectCodec(Stream<RtpCodec> codecs, String sdpOffer) {
+        Set<Integer> offeredPts = parseOfferedPayloadTypes(sdpOffer);
+        Map<Integer, String> rtpmap = parseRtpmap(sdpOffer);
+        Map<Integer, String> fmtp = parseFmtp(sdpOffer);
+
+        Optional<NegotiatedRtpCodec> selected = codecs.filter(RtpCodec::isAvailable)
+                .sorted(Comparator.comparingInt(RtpCodec::preference))
+                .flatMap(
+                        codec -> negotiatedPt(codec, offeredPts, rtpmap, fmtp)
+                                .map(pt -> new NegotiatedRtpCodec(codec.forCall(), pt))
+                                .stream())
+                .findFirst();
+
+        if (selected.isEmpty()) {
+            LOGGER.log(System.Logger.Level.DEBUG, "No matching codec found in SDP offer; falling back to PCMA (PT 8)");
+        }
+
+        NegotiatedRtpCodec result = selected.orElseGet(
+                () -> new NegotiatedRtpCodec(PcmaRtpCodec.INSTANCE.forCall(), PcmaRtpCodec.INSTANCE.payloadType()));
 
         LOGGER.log(
                 System.Logger.Level.DEBUG,
-                "Codec selected: {0} (PT {1}) from offered payload types {2}",
-                descriptor.sdpName(),
-                descriptor.payloadType(),
-                offeredPayloadTypes);
+                "Codec selected: {0} (negotiated PT {1}) from offered payload types {2}",
+                result.sdpName(),
+                result.payloadType(),
+                offeredPts);
 
-        return descriptor.forCall();
+        return result;
+    }
+
+    /**
+     * Finds the negotiated payload type for a codec against the offered payload types and rtpmap.
+     *
+     * <p>Iterates the rtpmap entries (in offer order) looking for entries whose codec key matches
+     * {@code "<sdpName>/<rtpClockRate>"} (case-insensitive) and whose fmtp parameters are
+     * accepted by {@link RtpCodec#matchesFmtp(String)}.
+     * Falls back to the codec's own static payload type if no rtpmap entry is present (e.g.
+     * PCMA at PT 8 offered without an explicit {@code a=rtpmap:8 PCMA/8000} line).
+     *
+     * @param codec      the codec descriptor to match
+     * @param offeredPts the set of payload types from the {@code m=audio} line
+     * @param rtpmap     map of payload type → codec key from {@code a=rtpmap} lines
+     * @param fmtp       map of payload type → fmtp params from {@code a=fmtp} lines
+     * @return the payload type to use, or empty if the codec is not compatible with this offer
+     */
+    private static Optional<Integer> negotiatedPt(
+            RtpCodec codec, Set<Integer> offeredPts, Map<Integer, String> rtpmap, Map<Integer, String> fmtp) {
+        String codecKey = (codec.sdpName() + "/" + codec.rtpClockRate()).toUpperCase();
+
+        // Find the first offered PT whose rtpmap matches this codec and whose fmtp is compatible.
+        Optional<Integer> fromRtpmap = rtpmap.entrySet().stream()
+                .filter(entry -> offeredPts.contains(entry.getKey()))
+                .filter(entry -> entry.getValue().equalsIgnoreCase(codecKey))
+                .filter(entry -> codec.matchesFmtp(fmtp.getOrDefault(entry.getKey(), "")))
+                .map(Map.Entry::getKey)
+                .findFirst();
+
+        if (fromRtpmap.isPresent()) {
+            return fromRtpmap;
+        }
+
+        // Fallback: static payload type (0–95), offered without an explicit rtpmap line.
+        if (offeredPts.contains(codec.payloadType()) && codec.matchesFmtp("")) {
+            return Optional.of(codec.payloadType());
+        }
+
+        return Optional.empty();
     }
 
     private static String buildSdpAnswer(String localIp, int localPort, RtpCodec codec, int telephoneEventPt) {

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
@@ -68,8 +68,8 @@ class SdpNegotiatorTest {
             a=rtpmap:110 AMR-WB/16000\r
             a=fmtp:110 octet-align=1;mode-set=0,1,2;mode-change-capability=2;max-red=0\r
             a=rtpmap:9 G722/8000\r
-            a=rtpmap:102 G722/8000\r
-            a=rtpmap:108 AMR/8000\r
+            a=rtpmap:102 AMR/8000\r
+            a=rtpmap:108 G722/8000\r
             a=rtpmap:8 PCMA/8000\r
             a=rtpmap:0 PCMU/8000\r
             a=rtpmap:100 telephone-event/16000\r

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
@@ -14,7 +14,13 @@ package de.bmarwell.proximo.pitido.war.media;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
+import java.util.Map;
+import java.util.stream.Stream;
 import org.junit.jupiter.api.Test;
 
 class SdpNegotiatorTest {
@@ -41,6 +47,34 @@ class SdpNegotiatorTest {
             t=0 0\r
             m=audio 49152 RTP/AVP 8\r
             a=rtpmap:8 PCMA/8000\r
+            a=sendrecv\r
+            """;
+
+    /**
+     * Real-world Deutsche Telekom VoLTE SDP offer (anonymised).
+     * AMR-WB appears twice: PT 104 (bandwidth-efficient, no octet-align) and PT 110 (octet-aligned).
+     * Our encoder only handles octet-aligned mode, so PT 110 must be selected.
+     */
+    private static final String SDP_OFFER_TELEKOM_VOLTE = """
+            v=0\r
+            o=- 3896854731 3896854731 IN IP4 10.20.30.40\r
+            s=-\r
+            c=IN IP4 10.20.30.40\r
+            t=0 0\r
+            m=audio 51944 RTP/AVP 109 104 110 9 102 108 8 0 100 105\r
+            a=rtpmap:109 EVS/16000\r
+            a=rtpmap:104 AMR-WB/16000\r
+            a=fmtp:104 mode-set=0,1,2;mode-change-capability=2;max-red=0\r
+            a=rtpmap:110 AMR-WB/16000\r
+            a=fmtp:110 octet-align=1;mode-set=0,1,2;mode-change-capability=2;max-red=0\r
+            a=rtpmap:9 G722/8000\r
+            a=rtpmap:102 G722/8000\r
+            a=rtpmap:108 AMR/8000\r
+            a=rtpmap:8 PCMA/8000\r
+            a=rtpmap:0 PCMU/8000\r
+            a=rtpmap:100 telephone-event/16000\r
+            a=rtpmap:105 telephone-event/8000\r
+            a=fmtp:105 0-15\r
             a=sendrecv\r
             """;
 
@@ -121,5 +155,51 @@ class SdpNegotiatorTest {
         } catch (ReflectiveOperationException reflectiveOperationException) {
             throw new AssertionError("Could not invoke buildSdpAnswer", reflectiveOperationException);
         }
+    }
+
+    @Test
+    void parseRtpmap_withTelekomVolteSdp_extractsAmrWbAtBothPayloadTypes() {
+        // given
+        String sdp = SDP_OFFER_TELEKOM_VOLTE;
+
+        // when
+        Map<Integer, String> rtpmap = SdpNegotiator.parseRtpmap(sdp);
+
+        // then
+        assertEquals("AMR-WB/16000", rtpmap.get(104), "PT 104 must map to AMR-WB/16000");
+        assertEquals("AMR-WB/16000", rtpmap.get(110), "PT 110 must map to AMR-WB/16000");
+        assertEquals("G722/8000", rtpmap.get(9), "PT 9 must map to G722/8000");
+    }
+
+    @Test
+    void selectCodec_withTelekomVolteSdp_selectsOctetAlignedAmrWbAtNegotiatedPayloadType() {
+        // given
+        String sdp = SDP_OFFER_TELEKOM_VOLTE;
+
+        RtpCodec g722Stub = mock(RtpCodec.class);
+        when(g722Stub.isAvailable()).thenReturn(true);
+        when(g722Stub.preference()).thenReturn(50);
+        when(g722Stub.sdpName()).thenReturn("G722");
+        when(g722Stub.rtpClockRate()).thenReturn(8000);
+        when(g722Stub.payloadType()).thenReturn(9);
+        when(g722Stub.matchesFmtp(anyString())).thenReturn(true);
+        when(g722Stub.forCall()).thenReturn(g722Stub);
+
+        RtpCodec amrWbStub = mock(RtpCodec.class);
+        when(amrWbStub.isAvailable()).thenReturn(true);
+        when(amrWbStub.preference()).thenReturn(40);
+        when(amrWbStub.sdpName()).thenReturn("AMR-WB");
+        when(amrWbStub.rtpClockRate()).thenReturn(16000);
+        when(amrWbStub.payloadType()).thenReturn(98);
+        when(amrWbStub.matchesFmtp(anyString()))
+                .thenAnswer(invocation -> ((String) invocation.getArgument(0)).contains("octet-align=1"));
+        when(amrWbStub.forCall()).thenReturn(amrWbStub);
+
+        // when
+        RtpCodec selected = SdpNegotiator.selectCodec(Stream.of(g722Stub, amrWbStub), sdp);
+
+        // then — AMR-WB must be selected at the octet-aligned PT 110, not the BW-efficient PT 104
+        assertEquals("AMR-WB", selected.sdpName(), "Selected codec must be AMR-WB");
+        assertEquals(110, selected.payloadType(), "Negotiated PT must be 110 (octet-aligned), not 104 (BW-efficient)");
     }
 }


### PR DESCRIPTION
## Problem

VoLTE callers (Deutsche Telekom, 1&1 mobile) assign AMR-WB under dynamic payload types per call via `a=rtpmap` lines.
The old `selectCodec()` matched codecs by `offeredPayloadTypes.contains(codec.payloadType())`, where `AmrWbRtpCodec.payloadType()` returned the conventional value 98.
98 was never in the offered set (Telekom uses PT 104 and PT 110 for AMR-WB), so AMR-WB was silently skipped and G.722 was selected instead.

## Root cause (from real trace log)

Telekom VoLTE SDP offer:
```
m=audio 51944 RTP/AVP 109 104 110 9 ...
a=rtpmap:104 AMR-WB/16000   ← bandwidth-efficient (no octet-align=1)
a=fmtp:104 mode-set=0,1,2;...
a=rtpmap:110 AMR-WB/16000   ← octet-aligned ✓
a=fmtp:110 octet-align=1;mode-set=0,1,2;...
```
PT 98 ∉ {109, 104, 110, 9, …} → AMR-WB filtered out → G.722 selected.

## Fix

- **`RtpCodec`**: add `default boolean matchesFmtp(String offeredFmtp)` (default: `true`).
- **`AmrWbRtpCodec`**: override `matchesFmtp()` to require `octet-align=1`, rejecting the bandwidth-efficient PT.
- **`NegotiatedRtpCodec`**: new package-private wrapper — delegates all methods to a per-call codec instance but overrides `payloadType()` to return the caller-assigned PT.
  This ensures outgoing RTP headers and the SDP answer use the PT the caller expects.
- **`SdpNegotiator`**: add `parseRtpmap()` and `parseFmtp()` static helpers; replace `selectCodec(Set<Integer>)` with `selectCodec(Stream<RtpCodec>, String)` matching by NAME/RATE key and wrapping result in `NegotiatedRtpCodec`.
- **`SdpNegotiatorTest`**: add Telekom VoLTE SDP constant and two tests (`parseRtpmap` + codec selection at PT 110).

Closes #57