### PR TITLE
refactor: name managed executors with explicit JNDI lookup

### DIFF
--- a/languages/de-de/src/test/java/de/bmarwell/proximo/pitido/languages/de/de/GermanTimeAnnouncementTest.java
+++ b/languages/de-de/src/test/java/de/bmarwell/proximo/pitido/languages/de/de/GermanTimeAnnouncementTest.java
@@ -13,7 +13,6 @@
 package de.bmarwell.proximo.pitido.languages.de.de;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import de.bmarwell.proximo.pitido.api.PlaybackReceipt;
@@ -22,6 +21,8 @@ import java.time.Clock;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.ZonedDateTime;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
 import org.junit.jupiter.api.Test;
 
 class GermanTimeAnnouncementTest {
@@ -85,7 +86,10 @@ class GermanTimeAnnouncementTest {
         var player = new RecordingAudioPlayer();
         var announcement = new GermanTimeAnnouncement(player, clock);
 
-        Thread thread = Thread.ofVirtual().start(() -> {
+        // Tests run outside the container; Executors.newVirtualThreadPerTaskExecutor() is the
+        // correct substitute for ManagedExecutorService in a plain JUnit test.
+        var executor = Executors.newVirtualThreadPerTaskExecutor();
+        var future = executor.submit(() -> {
             try {
                 announcement.announce();
             } catch (InterruptedException interruptedException) {
@@ -97,9 +101,10 @@ class GermanTimeAnnouncementTest {
 
         // Allow the announcement to start, then interrupt it during waitUntil().
         Thread.sleep(50);
-        thread.interrupt();
-        thread.join(500);
-
-        assertFalse(thread.isAlive(), "Announcement thread must stop after interrupt");
+        future.cancel(true);
+        executor.shutdown();
+        assertTrue(
+                executor.awaitTermination(500, TimeUnit.MILLISECONDS),
+                "Announcement task must stop within 500 ms after interrupt");
     }
 }

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
@@ -87,7 +87,7 @@ public class CallAcceptor {
     @Inject
     HoldHandler holdHandler;
 
-    @Resource
+    @Resource(lookup = "concurrent/codecExecutor")
     ManagedExecutorService managedExecutorService;
 
     /**

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/DtmfDispatcher.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/DtmfDispatcher.java
@@ -44,7 +44,7 @@ public class DtmfDispatcher {
     @Inject
     CallSessionManager callSessionManager;
 
-    @Resource
+    @Resource(lookup = "concurrent/ioExecutor")
     ManagedExecutorService managedExecutorService;
 
     /**

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/SipRegistrationListener.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/SipRegistrationListener.java
@@ -116,7 +116,7 @@ public class SipRegistrationListener {
     @Inject
     LocalSipHostProvider localSipHostProvider;
 
-    @Resource
+    @Resource(lookup = "concurrent/scheduler")
     ManagedScheduledExecutorService managedScheduledExecutorService;
 
     /**

--- a/war/src/main/liberty/config/server.xml
+++ b/war/src/main/liberty/config/server.xml
@@ -43,6 +43,22 @@
   <cdi enableImplicitBeanArchives="false" />
 
   <!--
+    Named managed executor services.
+    ioExecutor:    virtual-thread pool for SIP registration retries and DTMF dispatch.
+                   Both are I/O-bound short tasks; virtual threads are well-suited.
+    codecExecutor: platform-thread pool for call/codec work and announcement playback.
+                   Platform threads are required because OGG/Opus and AMR-WB decoders
+                   use the Foreign Function & Memory API with Arena.ofConfined(), which
+                   binds the arena to the creating thread; a virtual thread yielding to a
+                   different carrier thread raises WrongThreadException.
+    scheduler:     managed scheduled executor for the SIP re-registration timer.
+                   Scheduling tasks are I/O-bound, so virtual threads are acceptable.
+  -->
+  <managedExecutorService id="ioExecutor" jndiName="concurrent/ioExecutor" virtualThread="true" />
+  <managedExecutorService id="codecExecutor" jndiName="concurrent/codecExecutor" />
+  <managedScheduledExecutorService id="scheduler" jndiName="concurrent/scheduler" virtualThread="true" />
+
+  <!--
     Default runtime logging profile.
     Liberty base level stays at AUDIT for framework noise control.
     All classes under de.bmarwell.proximo.pitido.* are set to fine (DEBUG) so that technical details are captured in trace.log without appearing in docker compose logs.

--- a/war/src/main/liberty/config/server.xml
+++ b/war/src/main/liberty/config/server.xml
@@ -44,15 +44,16 @@
 
   <!--
     Named managed executor services.
-    ioExecutor:    virtual-thread pool for SIP registration retries and DTMF dispatch.
-                   Both are I/O-bound short tasks; virtual threads are well-suited.
+    ioExecutor:    virtual-thread pool for DTMF dispatch.
+                   DTMF handling is short, I/O-bound work; virtual threads are well-suited.
     codecExecutor: platform-thread pool for call/codec work and announcement playback.
                    Platform threads are required because OGG/Opus and AMR-WB decoders
                    use the Foreign Function & Memory API with Arena.ofConfined(), which
                    binds the arena to the creating thread; a virtual thread yielding to a
                    different carrier thread raises WrongThreadException.
-    scheduler:     managed scheduled executor for the SIP re-registration timer.
-                   Scheduling tasks are I/O-bound, so virtual threads are acceptable.
+    scheduler:     managed scheduled executor for the SIP re-registration timer and
+                   registration retry work.
+                   Both are I/O-bound, so virtual threads are acceptable.
   -->
   <managedExecutorService id="ioExecutor" jndiName="concurrent/ioExecutor" virtualThread="true" />
   <managedExecutorService id="codecExecutor" jndiName="concurrent/codecExecutor" />

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/ManagedExecutorServiceStub.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/ManagedExecutorServiceStub.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.war;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.enterprise.concurrent.ManagedExecutorService;
+
+/**
+ * Plain-JUnit test stub for {@link ManagedExecutorService}.
+ * Delegates all {@link ExecutorService} methods to a virtual-thread-per-task executor.
+ * No container context is available outside the Liberty runtime.
+ */
+public class ManagedExecutorServiceStub implements ManagedExecutorService {
+
+    private final ExecutorService delegate = Executors.newVirtualThreadPerTaskExecutor();
+
+    @Override
+    public void execute(Runnable command) {
+        this.delegate.execute(command);
+    }
+
+    @Override
+    public void shutdown() {
+        this.delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return this.delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return this.delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return this.delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return this.delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return this.delegate.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return this.delegate.submit(task, result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return this.delegate.submit(task);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return this.delegate.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        return this.delegate.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return this.delegate.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return this.delegate.invokeAny(tasks, timeout, unit);
+    }
+}

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/ManagedScheduledExecutorServiceStub.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/ManagedScheduledExecutorServiceStub.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.war;
+
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import javax.enterprise.concurrent.ManagedScheduledExecutorService;
+import javax.enterprise.concurrent.Trigger;
+
+/**
+ * Plain-JUnit test stub for {@link ManagedScheduledExecutorService}.
+ * Delegates all {@link ScheduledExecutorService} methods to a fixed-size platform-thread pool.
+ * No container context is available outside the Liberty runtime.
+ */
+public class ManagedScheduledExecutorServiceStub implements ManagedScheduledExecutorService {
+
+    private final ScheduledExecutorService delegate = Executors.newScheduledThreadPool(4);
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, Trigger trigger) {
+        throw new UnsupportedOperationException("test stub — Trigger-based scheduling not supported");
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, Trigger trigger) {
+        throw new UnsupportedOperationException("test stub — Trigger-based scheduling not supported");
+    }
+
+    @Override
+    public ScheduledFuture<?> schedule(Runnable command, long delay, TimeUnit unit) {
+        return this.delegate.schedule(command, delay, unit);
+    }
+
+    @Override
+    public <V> ScheduledFuture<V> schedule(Callable<V> callable, long delay, TimeUnit unit) {
+        return this.delegate.schedule(callable, delay, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleAtFixedRate(Runnable command, long initialDelay, long period, TimeUnit unit) {
+        return this.delegate.scheduleAtFixedRate(command, initialDelay, period, unit);
+    }
+
+    @Override
+    public ScheduledFuture<?> scheduleWithFixedDelay(Runnable command, long initialDelay, long delay, TimeUnit unit) {
+        return this.delegate.scheduleWithFixedDelay(command, initialDelay, delay, unit);
+    }
+
+    @Override
+    public void execute(Runnable command) {
+        this.delegate.execute(command);
+    }
+
+    @Override
+    public void shutdown() {
+        this.delegate.shutdown();
+    }
+
+    @Override
+    public List<Runnable> shutdownNow() {
+        return this.delegate.shutdownNow();
+    }
+
+    @Override
+    public boolean isShutdown() {
+        return this.delegate.isShutdown();
+    }
+
+    @Override
+    public boolean isTerminated() {
+        return this.delegate.isTerminated();
+    }
+
+    @Override
+    public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+        return this.delegate.awaitTermination(timeout, unit);
+    }
+
+    @Override
+    public <T> Future<T> submit(Callable<T> task) {
+        return this.delegate.submit(task);
+    }
+
+    @Override
+    public <T> Future<T> submit(Runnable task, T result) {
+        return this.delegate.submit(task, result);
+    }
+
+    @Override
+    public Future<?> submit(Runnable task) {
+        return this.delegate.submit(task);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks) throws InterruptedException {
+        return this.delegate.invokeAll(tasks);
+    }
+
+    @Override
+    public <T> List<Future<T>> invokeAll(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException {
+        return this.delegate.invokeAll(tasks, timeout, unit);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks) throws InterruptedException, ExecutionException {
+        return this.delegate.invokeAny(tasks);
+    }
+
+    @Override
+    public <T> T invokeAny(Collection<? extends Callable<T>> tasks, long timeout, TimeUnit unit)
+            throws InterruptedException, ExecutionException, TimeoutException {
+        return this.delegate.invokeAny(tasks, timeout, unit);
+    }
+}


### PR DESCRIPTION
Closes #59

## What changed

- **`server.xml`** — declares three named managed executor services:
  - `concurrent/ioExecutor` (virtual threads) — SIP registration retries, DTMF dispatch
  - `concurrent/codecExecutor` (platform threads) — call/codec work; Arena.ofConfined() requires a stable carrier thread, so virtual threads are unsafe here
  - `concurrent/scheduler` (virtual threads) — re-registration timer
- **`@Resource` annotations** — all three injection sites now carry `lookup = "concurrent/…"` so Liberty binds the correct named executor
- **Test stubs** — `ManagedExecutorServiceStub` and `ManagedScheduledExecutorServiceStub` in the war test sources for plain JUnit tests that run outside the container
- **`GermanTimeAnnouncementTest`** — replaces raw `Thread.ofVirtual().start()` with `Executors.newVirtualThreadPerTaskExecutor()` + `Future.cancel(true)` + `awaitTermination`