### PR TITLE
fix: auto-detect local SIP IP (#66) and fix SDP sendonly direction (#65)

### DIFF
--- a/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
+++ b/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
@@ -12,7 +12,10 @@
  */
 package de.bmarwell.proximo.pitido.core.sip;
 
+import java.io.IOException;
+import java.net.DatagramSocket;
 import java.net.Inet4Address;
+import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
 import java.util.Collections;
@@ -33,9 +36,12 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
  *       {@code SIP_REGISTRATION_ENABLED=true} and {@code SIP_PUBLIC_HOST} is absent.
  *       Behind NAT (home router, Docker host), a local IP in the Contact header is unreachable
  *       from the registrar, so a public IP is necessary.</li>
+ *   <li>Outbound interface IP detected via a connected {@link DatagramSocket} pointed at the
+ *       configured SIP registrar — reliable in Docker and Podman environments because it consults
+ *       the OS routing table rather than enumerating network interfaces.
+ *       No data is sent; the socket is used only for routing-table lookup.</li>
  *   <li>First non-loopback, non-link-local IPv4 address on any active network interface —
- *       used when registration is disabled (softphone / dev mode) or when all public-IP
- *       discovery services are unreachable.</li>
+ *       final fallback used when registration is disabled or all other detection methods fail.</li>
  * </ol>
  */
 @ApplicationScoped
@@ -50,6 +56,10 @@ public class LocalSipHostProvider {
     Optional<String> configuredHost;
 
     @Inject
+    @ConfigProperty(name = "sip.registrar")
+    Optional<String> registrar;
+
+    @Inject
     @ConfigProperty(name = "sip.registration.enabled", defaultValue = "true")
     boolean registrationEnabled;
 
@@ -62,16 +72,24 @@ public class LocalSipHostProvider {
     /** Returns the address to advertise in the SIP {@code Contact} header. */
     public String get() {
         if (this.configuredHost.isPresent()) {
-            return this.configuredHost.get();
+            String host = this.configuredHost.get();
+            LOGGER.log(System.Logger.Level.INFO, "Local SIP host (configured): {0}", host);
+
+            return host;
         }
 
         if (!this.registrationEnabled) {
-            return detectLocalAddress();
+            String host = detectLocalAddress();
+            LOGGER.log(System.Logger.Level.INFO, "Local SIP host (auto-detected, registration disabled): {0}", host);
+
+            return host;
         }
 
         Optional<String> publicIp = this.publicIpDiscoveryService.discover();
 
         if (publicIp.isPresent()) {
+            LOGGER.log(System.Logger.Level.INFO, "Local SIP host (public IP discovered): {0}", publicIp.get());
+
             return publicIp.get();
         }
 
@@ -79,10 +97,21 @@ public class LocalSipHostProvider {
                 System.Logger.Level.WARNING,
                 "All public IP discovery services unreachable; falling back to local IP for Contact header."
                         + " Incoming calls may fail if this host is behind NAT.");
-        return detectLocalAddress();
+        String host = detectLocalAddress();
+        LOGGER.log(System.Logger.Level.INFO, "Local SIP host (auto-detected fallback): {0}", host);
+
+        return host;
     }
 
     private String detectLocalAddress() {
+        if (this.registrar.isPresent()) {
+            Optional<String> routedAddress = detectViaRouting(this.registrar.get());
+
+            if (routedAddress.isPresent()) {
+                return routedAddress.get();
+            }
+        }
+
         try {
             return findLocalIpv4Address().orElse(FALLBACK_ADDRESS);
         } catch (SocketException socketException) {
@@ -90,7 +119,37 @@ public class LocalSipHostProvider {
                     System.Logger.Level.WARNING,
                     "Could not auto-detect local SIP host, using loopback",
                     socketException);
+
             return FALLBACK_ADDRESS;
+        }
+    }
+
+    /**
+     * Determines the outbound interface IP by connecting a UDP socket to the registrar.
+     *
+     * <p>No data is sent.
+     * The OS routing table selects the correct interface, which is the one Liberty will use
+     * for outbound SIP connections — making this reliable in Docker and Podman environments
+     * where interface enumeration may return multiple candidates.
+     */
+    private Optional<String> detectViaRouting(String registrarHost) {
+        try (DatagramSocket socket = new DatagramSocket()) {
+            socket.connect(InetAddress.getByName(registrarHost), 5060);
+            InetAddress localAddress = socket.getLocalAddress();
+
+            if (localAddress.isLoopbackAddress() || localAddress.isAnyLocalAddress()) {
+                return Optional.empty();
+            }
+
+            return Optional.of(localAddress.getHostAddress());
+        } catch (IOException ioException) {
+            LOGGER.log(
+                    System.Logger.Level.DEBUG,
+                    "Routing-table IP detection failed for registrar [{0}], falling back to NIC enumeration",
+                    registrarHost,
+                    ioException);
+
+            return Optional.empty();
         }
     }
 

--- a/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
+++ b/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
@@ -73,7 +73,7 @@ public class LocalSipHostProvider {
     public String get() {
         if (this.configuredHost.isPresent()) {
             String host = this.configuredHost.get();
-            LOGGER.log(System.Logger.Level.INFO, "Local SIP host (configured): {0}", host);
+            LOGGER.log(System.Logger.Level.INFO, "SIP Contact address (sip.public.host / SIP_PUBLIC_HOST): {0}", host);
 
             return host;
         }
@@ -88,7 +88,10 @@ public class LocalSipHostProvider {
         Optional<String> publicIp = this.publicIpDiscoveryService.discover();
 
         if (publicIp.isPresent()) {
-            LOGGER.log(System.Logger.Level.INFO, "Local SIP host (public IP discovered): {0}", publicIp.get());
+            LOGGER.log(
+                    System.Logger.Level.INFO,
+                    "SIP Contact address (public IP via PublicIpDiscoveryService): {0}",
+                    publicIp.get());
 
             return publicIp.get();
         }
@@ -137,7 +140,13 @@ public class LocalSipHostProvider {
             socket.connect(InetAddress.getByName(registrarHost), 5060);
             InetAddress localAddress = socket.getLocalAddress();
 
-            if (localAddress.isLoopbackAddress() || localAddress.isAnyLocalAddress()) {
+            if (localAddress.isLoopbackAddress()
+                    || localAddress.isAnyLocalAddress()
+                    || localAddress.isLinkLocalAddress()) {
+                return Optional.empty();
+            }
+
+            if (!(localAddress instanceof Inet4Address)) {
                 return Optional.empty();
             }
 

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -428,7 +428,7 @@ public class SdpNegotiator {
             sdp.append("a=fmtp:").append(telephoneEventPt).append(" 0-15\r\n");
         }
 
-        sdp.append("a=ptime:").append(PTIME_MS).append("\r\n").append("a=sendrecv\r\n");
+        sdp.append("a=ptime:").append(PTIME_MS).append("\r\n").append("a=sendonly\r\n");
 
         return sdp.toString();
     }

--- a/war/src/main/liberty/config/server.xml
+++ b/war/src/main/liberty/config/server.xml
@@ -16,12 +16,11 @@
   </featureManager>
 
   <!--
-    SIP_LOCAL_HOST (server.env): LAN IPv4 the SIP endpoint binds to.
-    Must be a real network interface IP (not loopback) so Liberty can establish
-    outbound TCP connections to the registrar. Defaults to "*" (auto), but "*"
-    resolves to 127.0.1.1 on many Linux systems — breaking outbound TCP.
+    SIP_LOCAL_HOST (server.env, optional): LAN IPv4 the SIP endpoint binds to.
+    If unset, the endpoint binds to all interfaces ("*").
+    Set this only when the host has multiple NICs and you need to force a specific one.
     SIP_PUBLIC_HOST (server.env): public IP advertised in the Contact header.
-    Port 5060 must be forwarded on the router: external 5060 → SIP_LOCAL_HOST:5060.
+    Port 5060 must be forwarded on the router: external 5060 → container port 5060.
   -->
   <variable name="sip.bind.host" value="${env.SIP_LOCAL_HOST}" defaultValue="*" />
   <sipEndpoint id="defaultSipEndpoint"

--- a/war/src/main/liberty/config/server.xml
+++ b/war/src/main/liberty/config/server.xml
@@ -20,7 +20,7 @@
     If unset, the endpoint binds to all interfaces ("*").
     Set this only when the host has multiple NICs and you need to force a specific one.
     SIP_PUBLIC_HOST (server.env): public IP advertised in the Contact header.
-    Port 5060 must be forwarded on the router: external 5060 → container port 5060.
+    Port 5060 must be reachable externally (forward on router or expose in container).
   -->
   <variable name="sip.bind.host" value="${env.SIP_LOCAL_HOST}" defaultValue="*" />
   <sipEndpoint id="defaultSipEndpoint"

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
@@ -103,17 +103,13 @@ class SdpNegotiatorTest {
     }
 
     @Test
-    void buildSdpAnswer_withTelephoneEvent_includesTelephoneEventLineAndSendrecv() {
+    void buildSdpAnswer_withTelephoneEvent_includesTelephoneEventLineAndSendonly() {
         // given — simulate the result of negotiate() for a simple PCMA + telephone-event offer
-        // The static method is package-private; test via the observable SDP string built inline
-        // using the same format as buildSdpAnswer (called reflectively through negotiate is heavier;
-        // testing the known output format is sufficient).
         String localIp = "192.168.1.1";
         int localPort = 20000;
         int telephoneEventPt = 101;
 
-        // when — call the package-private helper directly
-        // (same package, so direct access is allowed)
+        // when
         String sdpAnswer = invokeBuildSdpAnswer(localIp, localPort, telephoneEventPt);
 
         // then
@@ -121,11 +117,12 @@ class SdpNegotiatorTest {
                 sdpAnswer.contains("a=rtpmap:101 telephone-event/8000"),
                 "SDP answer must include telephone-event rtpmap");
         assertTrue(sdpAnswer.contains("a=fmtp:101 0-15"), "SDP answer must include telephone-event fmtp");
-        assertTrue(sdpAnswer.contains("a=sendrecv"), "SDP answer must use sendrecv when telephone-event is present");
+        assertTrue(
+                sdpAnswer.contains("a=sendonly"), "SDP answer must use sendonly — speaking clock never receives audio");
     }
 
     @Test
-    void buildSdpAnswer_withoutTelephoneEvent_isSendrecv() {
+    void buildSdpAnswer_withoutTelephoneEvent_isSendonly() {
         // given
         String localIp = "192.168.1.1";
         int localPort = 20000;
@@ -135,7 +132,7 @@ class SdpNegotiatorTest {
         String sdpAnswer = invokeBuildSdpAnswer(localIp, localPort, telephoneEventPt);
 
         // then
-        assertTrue(sdpAnswer.contains("a=sendrecv"), "SDP answer must use sendrecv even without telephone-event");
+        assertTrue(sdpAnswer.contains("a=sendonly"), "SDP answer must use sendonly even without telephone-event");
     }
 
     /**


### PR DESCRIPTION
Two fixes in separate commits.

## Commit 1 — fix(#66): auto-detect local SIP host via routing-table DatagramSocket

When `SIP_LOCAL_HOST` / `sip.public.host` is not configured, `LocalSipHostProvider` now consults the OS routing table by connecting a `DatagramSocket` (no data sent) to the SIP registrar host.
This reliably selects the correct outbound interface in Docker and Podman environments, where NIC enumeration may return multiple candidates.
`SIP_LOCAL_HOST` is now optional; it is only needed when forcing a specific NIC on multi-NIC hosts.
The resolved address is logged at `INFO` on every resolution so operators can verify it without inspecting `trace.log`.

Closes #66

## Commit 2 — fix(#65): SDP answer must advertise `a=sendonly`

A speaking-clock service only sends audio; it never captures the caller's stream.
`a=sendrecv` was incorrect and may cause strict IMS/VoLTE stacks to immediately tear down the call.
Changed to `a=sendonly` in `SdpNegotiator.buildSdpAnswer()` and updated the corresponding test assertions.

Closes #65