### PR TITLE
feat: add deploy/ — Containerfile, docker-compose, env.template (three startup modes)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -330,3 +330,7 @@ dist
 .ionide
 
 # End of https://www.toptal.com/developers/gitignore/api/maven,intellij+all,visualstudiocode,maven,java,netbeans,node,typescript
+
+# Próximo Pitido deploy helpers
+deploy/.last-built-sha
+deploy/.env

--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -1,0 +1,106 @@
+# =============================================================================
+# Próximo Pitido — container image
+# =============================================================================
+#
+# Two-stage build:
+#   Stage 1 (builder) — Eclipse Temurin HotSpot: compiles the Maven project.
+#   Stage 2 (runtime) — IBM Open Liberty on OpenJ9: serves the SIP application.
+#
+# Startup-time options (choose ONE block in Stage 2; the others stay commented):
+#
+#   Option A — no SCC (default)
+#     Fastest image build (~30 s on a modern CPU).
+#     Cold startup in ~15–20 s.
+#     Best choice when builds are frequent or hardware is modest.
+#
+#   Option B — OpenJ9 Shared Class Cache (SCC)
+#     Image build takes ~600 s (Liberty warms up the JVM and freezes the cache).
+#     Cold startup in ~3–5 s thereafter.
+#     Best choice when the image is built once and restarted many times.
+#
+#   Option C — InstantOn (IBM CRIU checkpoint/restore)
+#     Image build takes ~60 s (Liberty checkpoints after the app is ready).
+#     Startup in <1 s — the container resumes from a frozen process snapshot.
+#     Requires extra Linux capabilities when running (see docker-compose.yml).
+#     Best choice for auto-scaling or very latency-sensitive restarts.
+#     Needs the host kernel to support CRIU (Linux ≥ 5.9, CAP_CHECKPOINT_RESTORE).
+#
+# =============================================================================
+
+# ── Stage 1: Build ───────────────────────────────────────────────────────────
+# Eclipse Temurin (Eclipse Adoptium) — community-maintained HotSpot JDK,
+# no Oracle licence required.
+FROM eclipse-temurin:25-jdk-alpine AS builder
+
+RUN apk add --no-cache git
+
+# CACHE_BUST is set by the deploy script to the current HEAD SHA.
+# Docker reuses the git clone layer when the SHA is unchanged and rebuilds it
+# (together with all subsequent layers) only when main has new commits.
+ARG CACHE_BUST=
+ARG GIT_REF=main
+
+RUN echo "Building ref: ${GIT_REF} (${CACHE_BUST})" \
+    && git clone --depth=1 --branch="${GIT_REF}" \
+       https://github.com/bmarwell/proximo-pitido.git /build
+
+WORKDIR /build
+
+# The Maven local repository is a BuildKit cache mount.
+# It is shared across builds on the same host and is never baked into the image.
+RUN --mount=type=cache,target=/root/.m2 \
+    ./mvnw --batch-mode --no-transfer-progress \
+           -pl war -am -DskipTests \
+           clean package
+
+# ── Stage 2: Runtime ─────────────────────────────────────────────────────────
+# OpenJ9 is kept at runtime for its lower resident-set-size compared with HotSpot.
+FROM icr.io/appcafe/open-liberty:kernel-slim-java25-openj9-ubi-minimal
+
+# Install native libraries required by the audio codecs (FFM/Panama bindings):
+#   opus         → libopus.so.0        (OGG/Opus decoding)
+#   spandsp      → libspandsp.so.2     (G.722 wideband encoding)
+#   vo-amrwbenc  → libvo-amrwbenc.so.0 (AMR-WB encoding, required for VoLTE callers)
+#
+# spandsp and vo-amrwbenc are absent from the standard UBI repositories;
+# EPEL 9 and RPM Fusion free are added first.
+USER root
+RUN rpm -i https://dl.fedoraproject.org/pub/epel/epel-release-latest-9.noarch.rpm \
+    && rpm -i https://mirrors.rpmfusion.org/free/el/rpmfusion-free-release-9.noarch.rpm \
+    && microdnf install -y --nodocs opus spandsp vo-amrwbenc \
+    && microdnf clean all
+USER 1001
+
+# Copy Liberty server configuration (server.xml, dar.properties, sip.xml).
+# server.env is intentionally absent from the image; supply it via env_file at runtime.
+COPY --from=builder --chown=1001:0 /build/war/src/main/liberty/config/ /config/
+
+# Download and install only the Liberty features declared in server.xml.
+# This layer is cached until server.xml changes, so WAR-only updates skip it.
+RUN features.sh
+
+COPY --from=builder --chown=1001:0 /build/war/target/proximo-pitido-war-*.war /config/dropins/
+
+# ── Startup-time option A: no SCC (default) ──────────────────────────────────
+# Fastest build; Liberty starts cold in ~15–20 s.
+ENV OPENJ9_SCC=false
+RUN configure.sh
+
+# ── Startup-time option B: OpenJ9 Shared Class Cache ─────────────────────────
+# Comment out option A above and uncomment these two lines.
+# The image build will take ~600 s; subsequent cold starts will be ~3–5 s.
+#ENV OPENJ9_SCC=true
+#RUN configure.sh
+
+# ── Startup-time option C: InstantOn (IBM CRIU checkpoint/restore) ────────────
+# Comment out option A entirely and uncomment the RUN line below instead.
+# Also enable the extra capabilities in docker-compose.yml (see comments there).
+# Build requires: docker build --cap-add=CHECKPOINT_RESTORE --cap-add=SYS_PTRACE
+#                              --security-opt seccomp=unconfined
+# Startup will be <1 s; the container resumes from a frozen process snapshot.
+#RUN checkpoint.sh afterAppStart
+
+EXPOSE 5060/udp
+EXPOSE 5060/tcp
+EXPOSE 5061/tcp
+EXPOSE 9080/tcp

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -27,7 +27,6 @@ services:
       - "5060:5060/tcp"         # SIP signalling (TCP)
       - "5060:5060/udp"         # SIP signalling (UDP)
       - "5061:5061/tcp"         # SIP over TLS
-      - "5061:5061/udp"
       - "16384-16484:16384-16484/udp"  # RTP media (100-port window)
 
     # ── InstantOn (option C) only ─────────────────────────────────────────────

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -1,0 +1,40 @@
+# Próximo Pitido — docker-compose deployment example
+#
+# Copy this file alongside Containerfile and env.template.
+# Rename env.template to .env and fill in your SIP credentials before starting.
+#
+# Start:   docker compose up -d
+# Update:  ./update.sh
+# Logs:    docker compose logs -f
+# Stop:    docker compose down
+
+services:
+  proximo-pitido:
+    build:
+      context: .
+      dockerfile: Containerfile
+      args:
+        GIT_REF: main
+        # CACHE_BUST is set by update.sh to the current HEAD SHA.
+        # Override here only if you want to pin to a specific commit.
+        CACHE_BUST: ""
+    image: "proximo-pitido:latest"
+    container_name: proximo-pitido
+    restart: unless-stopped
+    env_file: .env
+    ports:
+      - "9080:9080/tcp"         # Liberty management / health endpoint
+      - "5060:5060/tcp"         # SIP signalling (TCP)
+      - "5060:5060/udp"         # SIP signalling (UDP)
+      - "5061:5061/tcp"         # SIP over TLS
+      - "5061:5061/udp"
+      - "16384-16484:16384-16484/udp"  # RTP media (100-port window)
+
+    # ── InstantOn (option C) only ─────────────────────────────────────────────
+    # Uncomment the block below when using checkpoint.sh in the Containerfile.
+    # The host kernel must support CRIU (Linux ≥ 5.9).
+    #cap_add:
+    #  - CHECKPOINT_RESTORE
+    #  - SYS_PTRACE
+    #security_opt:
+    #  - seccomp=unconfined

--- a/deploy/env.template
+++ b/deploy/env.template
@@ -1,0 +1,52 @@
+# Próximo Pitido — environment configuration template
+#
+# Copy this file to .env in the same directory as docker-compose.yml.
+# Fill in every value marked <required>.
+# The .env file must never be committed; it is listed in .gitignore.
+#
+# Variable names map to MicroProfile Config properties via the Liberty
+# env-var convention: underscores replace dots and the name is upper-cased.
+# For example, SIP_REGISTRAR maps to the MP Config key sip.registrar.
+
+# ── SIP provider ─────────────────────────────────────────────────────────────
+
+# Hostname of the SIP registrar (your VoIP provider's SIP server).
+# Example: sip.example.com
+SIP_REGISTRAR=<required>
+
+# The SIP identity (from-address) to register.
+# Typically the full SIP URI without the sip: scheme.
+# Example: 4930123456789@sip.example.com
+SIP_SIPID=<required>
+
+# Authentication username.
+# Some providers use an e-mail address; others use the phone number.
+# Example: user@example.com
+SIP_USER_ID=<required>
+
+# Authentication password (SIP account password, not your portal login).
+SIP_USER_PASSWORD=<required>
+
+# ── Network ──────────────────────────────────────────────────────────────────
+
+# Public IP address to advertise in the SIP Contact header and SDP.
+# Required when the container is behind NAT (home router, cloud instance).
+# If unset, Próximo Pitido auto-detects the outbound interface address
+# via a routing-table query — reliable inside Docker/Podman.
+# Set explicitly when auto-detection returns the wrong address.
+# Example: 203.0.113.42
+#SIP_PUBLIC_HOST=
+
+# LAN IP the SIP endpoint binds to inside the container.
+# Leave unset to bind to all interfaces ("*").
+# Set only when the host has multiple NICs and you need to force a specific one.
+# Example: 192.168.1.10
+#SIP_LOCAL_HOST=
+
+# ── Language selection ────────────────────────────────────────────────────────
+
+# Comma-separated BCP 47 language tags in the order they are offered to the caller.
+# Only languages present on the classpath are available.
+# Defaults to the order returned by LanguageFactory.getDefaultOrder() if unset.
+# Example: de,en
+#SIP_LANGUAGE_ORDER=

--- a/deploy/update.sh
+++ b/deploy/update.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+# Próximo Pitido — update and redeploy
+#
+# Usage: ./update.sh [-f]
+#   -f   force rebuild even when no new commits are available
+#
+# Requirements: docker (with BuildKit), git, internet access to github.com
+set -euo pipefail
+IFS=$'\n\t'
+
+SCRIPT_DIR=$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" &>/dev/null && pwd)
+cd "${SCRIPT_DIR}"
+
+FORCE="${1:-}"
+
+# Resolve the current HEAD SHA on main without cloning the full repository.
+# Docker uses this as a cache-bust key: only the git clone layer (and those
+# after it) are rebuilt when main has new commits.  Layers before the clone
+# (base image pull, native-library install) remain cached.
+HEAD_SHA=$(git ls-remote https://github.com/bmarwell/proximo-pitido.git main | cut -f1)
+
+if [[ -z "${HEAD_SHA}" ]]; then
+    echo "Could not resolve HEAD SHA from GitHub — aborting." >&2
+    exit 1
+fi
+
+# Read the SHA used for the last successful build, if any.
+LAST_SHA_FILE="${SCRIPT_DIR}/.last-built-sha"
+LAST_SHA=""
+
+if [[ -f "${LAST_SHA_FILE}" ]]; then
+    LAST_SHA=$(cat "${LAST_SHA_FILE}")
+fi
+
+if [[ "${HEAD_SHA}" == "${LAST_SHA}" ]] && [[ "${FORCE}" != "-f" ]]; then
+    echo "Already at HEAD ${HEAD_SHA} — nothing to do.  Pass -f to force a rebuild."
+    exit 0
+fi
+
+echo "Building HEAD ${HEAD_SHA}"
+
+docker compose build \
+    --build-arg "CACHE_BUST=${HEAD_SHA}" \
+    --build-arg "GIT_REF=main"
+
+docker compose up --no-color -d --force-recreate
+
+echo "${HEAD_SHA}" > "${LAST_SHA_FILE}"
+echo "Done."


### PR DESCRIPTION
Adds a self-contained `deploy/` directory operators can copy and use directly.

## Contents

| File | Purpose |
|------|---------|
| `Containerfile` | Two-stage build: Temurin HotSpot builder → Open Liberty OpenJ9 runtime |
| `docker-compose.yml` | Deployment descriptor; InstantOn caps commented for easy opt-in |
| `env.template` | All supported env vars with descriptions; copy to `.env` |
| `update.sh` | Resolves HEAD SHA, busts only the git-clone layer on new commits |

## Three startup modes (all in one Containerfile)

**Option A — no SCC (default)**
`OPENJ9_SCC=false` — fastest build (~30 s), cold start ~15–20 s.
Best for modest hardware or frequent deployments.

**Option B — OpenJ9 Shared Class Cache**
`OPENJ9_SCC=true` — build takes ~600 s; cold starts thereafter ~3–5 s.
Best when the image is built once and restarted many times.

**Option C — InstantOn (IBM CRIU checkpoint/restore)**
`checkpoint.sh afterAppStart` — build ~60 s, startup <1 s.
Requires `CAP_CHECKPOINT_RESTORE + SYS_PTRACE` on Linux ≥ 5.9.
Matching `cap_add`/`security_opt` lines are commented in `docker-compose.yml`.

Each inactive option is clearly commented so users can switch by uncommenting one block.

## Design notes
- BuildKit cache mount for `.m2` — dependencies survive across builds, never baked in.
- `CACHE_BUST=<HEAD SHA>` from `git ls-remote` — only the clone layer and later are invalidated on new commits; the native-lib install layer stays cached.
- `.env` and `.last-built-sha` added to `.gitignore`.