### PR TITLE
fix: correct WAR artifact path in Containerfile

### DIFF
--- a/deploy/Containerfile
+++ b/deploy/Containerfile
@@ -79,7 +79,7 @@ COPY --from=builder --chown=1001:0 /build/war/src/main/liberty/config/ /config/
 # This layer is cached until server.xml changes, so WAR-only updates skip it.
 RUN features.sh
 
-COPY --from=builder --chown=1001:0 /build/war/target/proximo-pitido-war-*.war /config/dropins/
+COPY --from=builder --chown=1001:0 /build/war/target/proximo-pitido.war /config/dropins/
 
 # ── Startup-time option A: no SCC (default) ──────────────────────────────────
 # Fastest build; Liberty starts cold in ~15–20 s.


### PR DESCRIPTION
finalName is 'proximo-pitido' (see war/pom.xml line 102), so the built artifact is proximo-pitido.war, not proximo-pitido-war-*.war.