### PR TITLE
fix: SIP endpoint binds to literal '${env.SIP_LOCAL_HOST}' when var is unset

### DIFF
--- a/war/src/main/liberty/config/server.xml
+++ b/war/src/main/liberty/config/server.xml
@@ -22,9 +22,9 @@
     SIP_PUBLIC_HOST (server.env): public IP advertised in the Contact header.
     Port 5060 must be reachable externally (forward on router or expose in container).
   -->
-  <variable name="sip.bind.host" value="${env.SIP_LOCAL_HOST}" defaultValue="*" />
+  <variable name="SIP_LOCAL_HOST" defaultValue="*" />
   <sipEndpoint id="defaultSipEndpoint"
-    host="${sip.bind.host}"
+    host="${SIP_LOCAL_HOST}"
     sipUDPPort="5060"
     sipTCPPort="5060"
     sipTLSPort="5061"


### PR DESCRIPTION
## Problem

When `SIP_LOCAL_HOST` is absent (commented out or not set), Liberty resolved `${env.SIP_LOCAL_HOST}` to the **literal string** `${env.SIP_LOCAL_HOST}` and assigned it to `sip.bind.host`.
Because `sip.bind.host` was therefore always *defined*, its `defaultValue="*"` was never applied.
Liberty then attempted to bind the SIP UDP/TCP endpoint to that literal hostname:

```
CWWKO0403E: The host ${env.SIP_LOCAL_HOST} could not be resolved.
```

This repeated every 5 seconds, the SIP stack never initialised, and `SipProvider` remained `null`, causing:

```
NullPointerException: Cannot invoke "jain.protocol.ip.sip.SipProvider.getListeningPoint()"
```

…and thus no REGISTER was ever sent.

## Fix

Replaced:
```xml
<variable name="sip.bind.host" value="${env.SIP_LOCAL_HOST}" defaultValue="*" />
<sipEndpoint host="${sip.bind.host}" … />
```

With:
```xml
<variable name="SIP_LOCAL_HOST" defaultValue="*" />
<sipEndpoint host="${SIP_LOCAL_HOST}" … />
```

Liberty automatically maps environment variables to config variables by name.
When `SIP_LOCAL_HOST` is absent, the `defaultValue="*"` now applies correctly and the endpoint binds to all interfaces.