### PR TITLE
fix(#64): call forCall() on announcement thread, not SDP-negotiation thread

### DIFF
--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
@@ -181,18 +181,16 @@ public class CallAcceptor {
         singleMenu.put(1, factory);
 
         Future<?> callFuture = this.managedExecutorService.submit(() -> {
-            // forCall() must run on the announcement thread so that the confined Arena is owned
-            // by the thread that will also call encode() and close() — preventing WrongThreadException.
-            var callCodec = media.codec().forCall();
-
             try {
                 Thread.sleep(1_000);
             } catch (InterruptedException interruptedException) {
                 Thread.currentThread().interrupt();
-                callCodec.close();
                 return;
             }
 
+            // forCall() must run on the announcement thread so that the confined Arena is owned
+            // by the thread that will also call encode() and close() — preventing WrongThreadException.
+            var callCodec = media.codec().forCall();
             AudioPlayer player = new RtpAudioPlayer(media, callCodec, this.pcmDecoderFactory);
 
             try {

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
@@ -180,16 +180,26 @@ public class CallAcceptor {
         LinkedHashMap<Integer, LanguageFactory> singleMenu = new LinkedHashMap<>();
         singleMenu.put(1, factory);
 
-        AudioPlayer player = new RtpAudioPlayer(media, this.pcmDecoderFactory);
         Future<?> callFuture = this.managedExecutorService.submit(() -> {
+            // forCall() must run on the announcement thread so that the confined Arena is owned
+            // by the thread that will also call encode() and close() — preventing WrongThreadException.
+            var callCodec = media.codec().forCall();
+
             try {
                 Thread.sleep(1_000);
             } catch (InterruptedException interruptedException) {
                 Thread.currentThread().interrupt();
+                callCodec.close();
                 return;
             }
 
-            this.announcementLoop.play(session, player, factory, sessionId, media);
+            AudioPlayer player = new RtpAudioPlayer(media, callCodec, this.pcmDecoderFactory);
+
+            try {
+                this.announcementLoop.play(session, player, factory, sessionId, media);
+            } finally {
+                callCodec.close();
+            }
         });
 
         this.callSessionManager.register(
@@ -211,7 +221,6 @@ public class CallAcceptor {
         CallMedia media =
                 negotiateAndRespond(req, sessionId, "language-selection menu (" + menu.size() + " languages)");
 
-        AudioPlayer player = new RtpAudioPlayer(media, this.pcmDecoderFactory);
         Instant startTime = Instant.now();
         String callerIdentitySummary = SipCallHeaders.buildCallerIdentitySummary(req);
         LOGGER.log(
@@ -220,8 +229,18 @@ public class CallAcceptor {
                 SipCallHeaders.callPrefix(sessionId),
                 callerIdentitySummary);
 
-        Future<?> callFuture =
-                this.managedExecutorService.submit(() -> this.menuRunner.run(session, player, menu, sessionId, media));
+        Future<?> callFuture = this.managedExecutorService.submit(() -> {
+            // forCall() must run on the menu thread so that the confined Arena is owned
+            // by the thread that will also call encode() and close() — preventing WrongThreadException.
+            var callCodec = media.codec().forCall();
+            AudioPlayer player = new RtpAudioPlayer(media, callCodec, this.pcmDecoderFactory);
+
+            try {
+                this.menuRunner.run(session, player, menu, sessionId, media);
+            } finally {
+                callCodec.close();
+            }
+        });
         Future<?> receiverFuture = this.dtmfDispatcher.startReceiver(media, sessionId);
 
         this.callSessionManager.register(

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/NegotiatedRtpCodec.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/NegotiatedRtpCodec.java
@@ -16,8 +16,8 @@ import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
 import java.io.IOException;
 
 /**
- * Wraps a per-call {@link RtpCodec} instance and overrides {@link #payloadType()} to return the
- * payload type actually negotiated with the caller rather than the codec's static default.
+ * Wraps a {@link RtpCodec} and overrides {@link #payloadType()} to return the payload type
+ * actually negotiated with the caller rather than the codec's static default.
  *
  * <p>VoLTE callers (e.g. Deutsche Telekom) assign dynamic payload types (96–127) per-call via
  * {@code a=rtpmap} lines.
@@ -26,9 +26,22 @@ import java.io.IOException;
  * This wrapper carries the actual PT assigned by the caller so that outgoing RTP packet headers
  * and the SDP answer use the same PT value the caller expects.
  *
- * <p>All methods other than {@link #payloadType()} delegate to the wrapped per-call codec instance.
+ * <h2>Lifecycle</h2>
  *
- * @param delegate               the per-call codec instance obtained from {@link RtpCodec#forCall()}
+ * <p>{@link de.bmarwell.proximo.pitido.war.media.SdpNegotiator#negotiate} returns an instance
+ * whose {@code delegate} is the CDI bean descriptor — no confined arena is allocated yet.
+ * The announcement or menu-runner lambda calls {@link #forCall()} at its start, on the executor
+ * thread that will also call {@link #encode} and {@link #close}.
+ * This guarantees that the {@link java.lang.foreign.Arena#ofConfined() confined arena} created by
+ * native codecs is owned by the thread that uses and closes it, preventing
+ * {@link java.lang.WrongThreadException}.
+ *
+ * <p>All methods other than {@link #payloadType()} and {@link #forCall()} delegate transparently
+ * to the wrapped codec instance.
+ *
+ * @param delegate               the codec instance; either a CDI bean descriptor (before
+ *                               {@link #forCall()}) or a per-call instance (after
+ *                               {@link #forCall()})
  * @param negotiatedPayloadType  the payload type assigned by the caller in the SDP offer
  */
 record NegotiatedRtpCodec(RtpCodec delegate, int negotiatedPayloadType) implements RtpCodec {

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpAudioPlayer.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpAudioPlayer.java
@@ -68,19 +68,36 @@ public class RtpAudioPlayer implements AudioPlayer {
      * Creates an {@link RtpAudioPlayer} bound to the media session in {@code callMedia}.
      *
      * @param callMedia         the negotiated call media; the socket must still be open
+     * @param callCodec         the per-call codec instance obtained by calling
+     *                          {@code callMedia.codec().forCall()} on the announcement thread;
+     *                          must be closed by the caller after the call ends
      * @param pcmDecoderFactory the factory used to select the decoder for each audio resource
      */
-    public RtpAudioPlayer(CallMedia callMedia, PcmDecoderFactory pcmDecoderFactory) {
+    public RtpAudioPlayer(CallMedia callMedia, RtpCodec callCodec, PcmDecoderFactory pcmDecoderFactory) {
         this.callMedia = callMedia;
         this.socket = callMedia.localSocket();
         this.remoteRtp = callMedia.remoteRtp();
         this.pcmDecoderFactory = pcmDecoderFactory;
-        this.codec = callMedia.codec();
+        this.codec = callCodec;
 
         Random rng = new Random();
         this.ssrc = rng.nextInt();
         this.seqNumber = rng.nextInt(0x10000);
         this.timestamp = rng.nextInt(Integer.MAX_VALUE) & 0xFFFFFFFFL;
+    }
+
+    /**
+     * Creates an {@link RtpAudioPlayer} bound to the media session in {@code callMedia}.
+     *
+     * @param callMedia         the negotiated call media; the socket must still be open
+     * @param pcmDecoderFactory the factory used to select the decoder for each audio resource
+     * @deprecated Use {@link #RtpAudioPlayer(CallMedia, RtpCodec, PcmDecoderFactory)} instead.
+     *             Passing the codec explicitly ensures the confined arena is created on the
+     *             thread that will encode and close it, preventing {@link WrongThreadException}.
+     */
+    @Deprecated
+    public RtpAudioPlayer(CallMedia callMedia, PcmDecoderFactory pcmDecoderFactory) {
+        this(callMedia, callMedia.codec(), pcmDecoderFactory);
     }
 
     /**

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpAudioPlayer.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpAudioPlayer.java
@@ -87,20 +87,6 @@ public class RtpAudioPlayer implements AudioPlayer {
     }
 
     /**
-     * Creates an {@link RtpAudioPlayer} bound to the media session in {@code callMedia}.
-     *
-     * @param callMedia         the negotiated call media; the socket must still be open
-     * @param pcmDecoderFactory the factory used to select the decoder for each audio resource
-     * @deprecated Use {@link #RtpAudioPlayer(CallMedia, RtpCodec, PcmDecoderFactory)} instead.
-     *             Passing the codec explicitly ensures the confined arena is created on the
-     *             thread that will encode and close it, preventing {@link WrongThreadException}.
-     */
-    @Deprecated
-    public RtpAudioPlayer(CallMedia callMedia, PcmDecoderFactory pcmDecoderFactory) {
-        this(callMedia, callMedia.codec(), pcmDecoderFactory);
-    }
-
-    /**
      * Sends silence RTP packets for exactly {@code duration}, keeping the receiver's jitter
      * buffer alive so the next audio plays with the correct timing gap.
      *

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -284,8 +284,9 @@ public class SdpNegotiator {
      * <p>Falls back to {@link PcmaRtpCodec#INSTANCE} if no injected codec matches.
      *
      * @param sdpOffer the full SDP offer string from the INVITE body
-     * @return a per-call codec instance whose {@link RtpCodec#payloadType()} returns the PT
-     *         that was actually negotiated with the caller
+     * @return a codec descriptor (CDI bean) whose {@link RtpCodec#payloadType()} returns the PT
+     *         actually negotiated with the caller; callers must call {@link RtpCodec#forCall()}
+     *         on the announcement thread before encoding
      */
     private RtpCodec selectCodec(String sdpOffer) {
         return selectCodec(this.availableCodecs.stream(), sdpOffer);
@@ -298,7 +299,8 @@ public class SdpNegotiator {
      *
      * @param codecs   available codec descriptors, each an {@code @ApplicationScoped} CDI bean
      * @param sdpOffer the full SDP offer string from the INVITE body
-     * @return a {@link NegotiatedRtpCodec} wrapping the selected per-call codec instance
+     * @return a {@link NegotiatedRtpCodec} wrapping the selected codec descriptor with the
+     *         negotiated payload type; call {@link RtpCodec#forCall()} on the announcement thread
      */
     static RtpCodec selectCodec(Stream<RtpCodec> codecs, String sdpOffer) {
         Set<Integer> offeredPts = parseOfferedPayloadTypes(sdpOffer);
@@ -307,9 +309,9 @@ public class SdpNegotiator {
 
         Optional<NegotiatedRtpCodec> selected = codecs.filter(RtpCodec::isAvailable)
                 .sorted(Comparator.comparingInt(RtpCodec::preference))
-                .flatMap(
-                        codec -> negotiatedPt(codec, offeredPts, rtpmap, fmtp)
-                                .map(pt -> new NegotiatedRtpCodec(codec.forCall(), pt))
+                .flatMap(codec ->
+                        negotiatedPt(codec, offeredPts, rtpmap, fmtp)
+                                .map(pt -> new NegotiatedRtpCodec(codec, pt))
                                 .stream())
                 .findFirst();
 
@@ -318,7 +320,7 @@ public class SdpNegotiator {
         }
 
         NegotiatedRtpCodec result = selected.orElseGet(
-                () -> new NegotiatedRtpCodec(PcmaRtpCodec.INSTANCE.forCall(), PcmaRtpCodec.INSTANCE.payloadType()));
+                () -> new NegotiatedRtpCodec(PcmaRtpCodec.INSTANCE, PcmaRtpCodec.INSTANCE.payloadType()));
 
         LOGGER.log(
                 System.Logger.Level.DEBUG,

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
@@ -199,4 +199,29 @@ class SdpNegotiatorTest {
         assertEquals("AMR-WB", selected.sdpName(), "Selected codec must be AMR-WB");
         assertEquals(110, selected.payloadType(), "Negotiated PT must be 110 (octet-aligned), not 104 (BW-efficient)");
     }
+
+    @Test
+    void selectCodec_doesNotCallForCallEagerly_delegateIsOriginalBean() {
+        // given — a stateful codec stub whose forCall() returns a distinct per-call instance
+        RtpCodec perCallInstance = mock(RtpCodec.class);
+        when(perCallInstance.sdpName()).thenReturn("PCMA");
+        when(perCallInstance.payloadType()).thenReturn(8);
+
+        RtpCodec descriptorStub = mock(RtpCodec.class);
+        when(descriptorStub.isAvailable()).thenReturn(true);
+        when(descriptorStub.preference()).thenReturn(100);
+        when(descriptorStub.sdpName()).thenReturn("PCMA");
+        when(descriptorStub.rtpClockRate()).thenReturn(8000);
+        when(descriptorStub.payloadType()).thenReturn(8);
+        when(descriptorStub.matchesFmtp(anyString())).thenReturn(true);
+        when(descriptorStub.forCall()).thenReturn(perCallInstance);
+
+        // when
+        RtpCodec selected = SdpNegotiator.selectCodec(Stream.of(descriptorStub), SDP_OFFER_WITH_TELEPHONE_EVENT);
+
+        // then — forCall() must NOT have been called during codec selection;
+        // the announcement thread must call it, not the SDP-negotiation thread.
+        org.mockito.Mockito.verify(descriptorStub, org.mockito.Mockito.never()).forCall();
+        assertEquals(8, selected.payloadType());
+    }
 }

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
@@ -201,7 +201,7 @@ class SdpNegotiatorTest {
     }
 
     @Test
-    void selectCodec_doesNotCallForCallEagerly_delegateIsOriginalBean() {
+    void selectCodec_doesNotCallForCallEagerly_wrapsDelegateDescriptor() {
         // given — a stateful codec stub whose forCall() returns a distinct per-call instance
         RtpCodec perCallInstance = mock(RtpCodec.class);
         when(perCallInstance.sdpName()).thenReturn("PCMA");
@@ -223,5 +223,7 @@ class SdpNegotiatorTest {
         // the announcement thread must call it, not the SDP-negotiation thread.
         org.mockito.Mockito.verify(descriptorStub, org.mockito.Mockito.never()).forCall();
         assertEquals(8, selected.payloadType());
+        // The returned wrapper must hold the original descriptor, not a per-call instance.
+        assertEquals(descriptorStub, ((NegotiatedRtpCodec) selected).delegate());
     }
 }


### PR DESCRIPTION
## Problem

`Arena.ofConfined()` creates a thread-confined arena.
`SdpNegotiator.selectCodec()` was calling `forCall()` (and thus creating the arena) on the SDP-negotiation thread (thread B).
The announcement lambda was submitted to `managedExecutorService` and ran on a different thread (thread C).
Any call to `encode()` or `close()` from thread C on the arena owned by thread B threw `WrongThreadException`, causing Android callers to hear nothing.

## Fix

- `SdpNegotiator.selectCodec()` now stores the **CDI bean descriptor** in `NegotiatedRtpCodec` without calling `forCall()`.
- `CallAcceptor.acceptAndAnnounce()` and `acceptAndPlayMenu()` call `forCall()` at the **start of the announcement/menu lambda**, on the same executor thread that will also call `encode()` and `close()`.
- `RtpAudioPlayer` gains an explicit `RtpCodec` constructor parameter; the old `(CallMedia, PcmDecoderFactory)` constructor is deprecated and delegates.
- `NegotiatedRtpCodec` Javadoc updated to describe both lifecycle roles (descriptor before `forCall()`, per-call instance after).
- `SdpNegotiatorTest` asserts `forCall()` is **never** called during codec selection.

Closes #64