### PR TITLE
fix: reject duplicate INVITE forks from Telekom IMS (SIP call forking)

### DIFF
--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
@@ -99,10 +99,24 @@ public class CallAcceptor {
      */
     public void accept(SipServletRequest req) throws IOException {
         String callId = req.getSession().getId();
+        String sipCallId = req.getCallId();
 
         if (this.callSessionManager.get(callId) != null) {
             // Re-INVITE on an established session: handle hold/unhold.
             this.holdHandler.handle(req);
+
+            return;
+        }
+
+        if (!this.callSessionManager.tryClaimSipCallId(sipCallId, callId)) {
+            // Duplicate INVITE fork for the same SIP Call-ID — Telekom routes INVITEs over
+            // multiple TCP paths simultaneously; reject this fork so only one session is created.
+            LOGGER.log(
+                    System.Logger.Level.DEBUG,
+                    "{0}Rejecting duplicate INVITE fork for SIP Call-ID [{1}]",
+                    SipCallHeaders.callPrefix(callId),
+                    sipCallId);
+            req.createResponse(SipServletResponse.SC_BUSY_HERE).send();
 
             return;
         }
@@ -120,6 +134,7 @@ public class CallAcceptor {
                     "{0}Rejecting blacklisted call from [{1}]",
                     SipCallHeaders.callPrefix(callId),
                     req.getFrom());
+            this.callSessionManager.releaseSipCallId(sipCallId);
             req.createResponse(SipServletResponse.SC_FORBIDDEN).send();
 
             return;
@@ -129,32 +144,34 @@ public class CallAcceptor {
         var menu = buildLanguageMenu(sorted);
 
         if (menu.isEmpty()) {
+            this.callSessionManager.releaseSipCallId(sipCallId);
             rejectNoLanguage(req, callId);
 
             return;
         }
 
         req.createResponse(SipServletResponse.SC_RINGING).send();
-        this.managedExecutorService.execute(() -> processAcceptedInvite(req, menu, callId));
+        this.managedExecutorService.execute(() -> processAcceptedInvite(req, menu, callId, sipCallId));
     }
 
     private void processAcceptedInvite(
-            SipServletRequest req, SequencedMap<Integer, LanguageFactory> menu, String callId) {
+            SipServletRequest req, SequencedMap<Integer, LanguageFactory> menu, String callId, String sipCallId) {
         try {
             Thread.sleep(1_000);
         } catch (InterruptedException interruptedException) {
             Thread.currentThread().interrupt();
+            this.callSessionManager.releaseSipCallId(sipCallId);
             return;
         }
 
         try {
             if (menu.size() == 1) {
-                acceptAndAnnounce(req, menu.firstEntry().getValue());
+                acceptAndAnnounce(req, menu.firstEntry().getValue(), sipCallId);
 
                 return;
             }
 
-            acceptAndPlayMenu(req, menu);
+            acceptAndPlayMenu(req, menu, sipCallId);
         } catch (IOException ioException) {
             LOGGER.log(
                     System.Logger.Level.ERROR,
@@ -162,10 +179,12 @@ public class CallAcceptor {
                     SipCallHeaders.callPrefix(callId),
                     req.getFrom(),
                     ioException);
+            this.callSessionManager.releaseSipCallId(sipCallId);
         }
     }
 
-    private void acceptAndAnnounce(SipServletRequest req, LanguageFactory factory) throws IOException {
+    private void acceptAndAnnounce(SipServletRequest req, LanguageFactory factory, String sipCallId)
+            throws IOException {
         SipSession session = req.getSession();
         String sessionId = session.getId();
         CallMedia media = negotiateAndRespond(req, sessionId, "language [" + factory.displayName() + "]");
@@ -195,6 +214,7 @@ public class CallAcceptor {
         this.callSessionManager.register(
                 sessionId,
                 new CallState(
+                        sipCallId,
                         session,
                         callFuture,
                         CompletableFuture.completedFuture(null),
@@ -204,7 +224,7 @@ public class CallAcceptor {
                         callerIdentitySummary));
     }
 
-    private void acceptAndPlayMenu(SipServletRequest req, SequencedMap<Integer, LanguageFactory> menu)
+    private void acceptAndPlayMenu(SipServletRequest req, SequencedMap<Integer, LanguageFactory> menu, String sipCallId)
             throws IOException {
         SipSession session = req.getSession();
         String sessionId = session.getId();
@@ -226,7 +246,8 @@ public class CallAcceptor {
 
         this.callSessionManager.register(
                 sessionId,
-                new CallState(session, callFuture, receiverFuture, menu, media, startTime, callerIdentitySummary));
+                new CallState(
+                        sipCallId, session, callFuture, receiverFuture, menu, media, startTime, callerIdentitySummary));
     }
 
     /**

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
@@ -98,23 +98,23 @@ public class CallAcceptor {
      * executor task.
      */
     public void accept(SipServletRequest req) throws IOException {
-        String callId = req.getSession().getId();
+        String sessionId = req.getSession().getId();
         String sipCallId = req.getCallId();
 
-        if (this.callSessionManager.get(callId) != null) {
+        if (this.callSessionManager.get(sessionId) != null) {
             // Re-INVITE on an established session: handle hold/unhold.
             this.holdHandler.handle(req);
 
             return;
         }
 
-        if (!this.callSessionManager.tryClaimSipCallId(sipCallId, callId)) {
+        if (!this.callSessionManager.tryClaimSipCallId(sipCallId)) {
             // Duplicate INVITE fork for the same SIP Call-ID — Telekom routes INVITEs over
             // multiple TCP paths simultaneously; reject this fork so only one session is created.
             LOGGER.log(
                     System.Logger.Level.DEBUG,
                     "{0}Rejecting duplicate INVITE fork for SIP Call-ID [{1}]",
-                    SipCallHeaders.callPrefix(callId),
+                    SipCallHeaders.callPrefix(sessionId),
                     sipCallId);
             req.createResponse(SipServletResponse.SC_BUSY_HERE).send();
 
@@ -124,7 +124,7 @@ public class CallAcceptor {
         LOGGER.log(
                 System.Logger.Level.INFO,
                 "{0}INVITE from [{1}] to [{2}]",
-                SipCallHeaders.callPrefix(callId),
+                SipCallHeaders.callPrefix(sessionId),
                 req.getFrom(),
                 req.getTo());
 
@@ -132,7 +132,7 @@ public class CallAcceptor {
             LOGGER.log(
                     System.Logger.Level.INFO,
                     "{0}Rejecting blacklisted call from [{1}]",
-                    SipCallHeaders.callPrefix(callId),
+                    SipCallHeaders.callPrefix(sessionId),
                     req.getFrom());
             this.callSessionManager.releaseSipCallId(sipCallId);
             req.createResponse(SipServletResponse.SC_FORBIDDEN).send();
@@ -145,41 +145,49 @@ public class CallAcceptor {
 
         if (menu.isEmpty()) {
             this.callSessionManager.releaseSipCallId(sipCallId);
-            rejectNoLanguage(req, callId);
+            rejectNoLanguage(req, sessionId);
 
             return;
         }
 
-        req.createResponse(SipServletResponse.SC_RINGING).send();
-        this.managedExecutorService.execute(() -> processAcceptedInvite(req, menu, callId, sipCallId));
+        try {
+            req.createResponse(SipServletResponse.SC_RINGING).send();
+        } catch (IOException ioException) {
+            this.callSessionManager.releaseSipCallId(sipCallId);
+
+            throw ioException;
+        }
+
+        this.managedExecutorService.execute(() -> processAcceptedInvite(req, menu, sessionId, sipCallId));
     }
 
     private void processAcceptedInvite(
-            SipServletRequest req, SequencedMap<Integer, LanguageFactory> menu, String callId, String sipCallId) {
+            SipServletRequest req, SequencedMap<Integer, LanguageFactory> menu, String sessionId, String sipCallId) {
+        boolean sessionRegistered = false;
+
         try {
             Thread.sleep(1_000);
-        } catch (InterruptedException interruptedException) {
-            Thread.currentThread().interrupt();
-            this.callSessionManager.releaseSipCallId(sipCallId);
-            return;
-        }
 
-        try {
             if (menu.size() == 1) {
                 acceptAndAnnounce(req, menu.firstEntry().getValue(), sipCallId);
-
-                return;
+            } else {
+                acceptAndPlayMenu(req, menu, sipCallId);
             }
 
-            acceptAndPlayMenu(req, menu, sipCallId);
+            sessionRegistered = true;
+        } catch (InterruptedException interruptedException) {
+            Thread.currentThread().interrupt();
         } catch (IOException ioException) {
             LOGGER.log(
                     System.Logger.Level.ERROR,
                     "{0}Failed to accept call from [{1}]",
-                    SipCallHeaders.callPrefix(callId),
+                    SipCallHeaders.callPrefix(sessionId),
                     req.getFrom(),
                     ioException);
-            this.callSessionManager.releaseSipCallId(sipCallId);
+        } finally {
+            if (!sessionRegistered) {
+                this.callSessionManager.releaseSipCallId(sipCallId);
+            }
         }
     }
 
@@ -307,11 +315,11 @@ public class CallAcceptor {
         return menu;
     }
 
-    private static void rejectNoLanguage(SipServletRequest req, String callId) throws IOException {
+    private static void rejectNoLanguage(SipServletRequest req, String sessionId) throws IOException {
         LOGGER.log(
                 System.Logger.Level.WARNING,
                 "{0}No language factories registered — rejecting incoming call with 480 Temporarily Unavailable",
-                SipCallHeaders.callPrefix(callId));
+                SipCallHeaders.callPrefix(sessionId));
         req.createResponse(SipServletResponse.SC_TEMPORARLY_UNAVAILABLE).send();
     }
 }

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
@@ -30,6 +30,11 @@ import javax.servlet.sip.SipSession;
  * <p>Stores per-call {@link CallState}, records pending DTMF language selections, and handles
  * orderly teardown on BYE or Liberty shutdown.
  * All other handler beans read and write call state through this class.
+ *
+ * <p>Telekom (and other IMS providers) may fork the same INVITE over two parallel TCP paths.
+ * The SIP Call-ID is the same on both forks.
+ * {@code claimedSipCallIds} tracks which SIP Call-IDs are currently being handled so that the
+ * second fork can be rejected with {@code 486 Busy Here} before it creates a second session.
  */
 @ApplicationScoped
 public class CallSessionManager {
@@ -39,10 +44,31 @@ public class CallSessionManager {
     private final ConcurrentHashMap<String, CallState> activeCalls = new ConcurrentHashMap<>();
 
     /**
+     * SIP Call-IDs currently being handled, claimed atomically before {@code 180 Ringing} is sent.
+     * Maps SIP Call-ID → Liberty session ID.
+     */
+    private final ConcurrentHashMap<String, String> claimedSipCallIds = new ConcurrentHashMap<>();
+
+    /**
      * Language selections written by the DTMF dispatcher; read (and cleared) by the menu runner
      * once the menu playback is interrupted.
      */
     private final ConcurrentHashMap<String, LanguageFactory> pendingSelections = new ConcurrentHashMap<>();
+
+    /**
+     * Atomically claims a SIP Call-ID for the given Liberty session.
+     * Returns {@code true} if the claim succeeded (no other session was already handling this
+     * Call-ID), or {@code false} if the Call-ID was already claimed — indicating a duplicate
+     * INVITE fork that should be rejected.
+     */
+    boolean tryClaimSipCallId(String sipCallId, String sessionId) {
+        return this.claimedSipCallIds.putIfAbsent(sipCallId, sessionId) == null;
+    }
+
+    /** Releases a previously claimed SIP Call-ID. */
+    void releaseSipCallId(String sipCallId) {
+        this.claimedSipCallIds.remove(sipCallId);
+    }
 
     void register(String sessionId, CallState state) {
         this.activeCalls.put(sessionId, state);
@@ -53,7 +79,13 @@ public class CallSessionManager {
     }
 
     CallState remove(String sessionId) {
-        return this.activeCalls.remove(sessionId);
+        CallState removed = this.activeCalls.remove(sessionId);
+
+        if (removed != null) {
+            releaseSipCallId(removed.sipCallId());
+        }
+
+        return removed;
     }
 
     /**
@@ -95,6 +127,8 @@ public class CallSessionManager {
             return;
         }
 
+        releaseSipCallId(callState.sipCallId());
+
         callState.callFuture().cancel(true);
         callState.receiverFuture().cancel(true);
         String codecName = callState.media().codec().sdpName();
@@ -132,6 +166,7 @@ public class CallSessionManager {
             sendBye(callState.session());
         });
         this.activeCalls.clear();
+        this.claimedSipCallIds.clear();
     }
 
     /**

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
@@ -17,6 +17,7 @@ import de.bmarwell.proximo.pitido.war.media.CallMedia;
 import java.io.IOException;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.PreDestroy;
 import javax.enterprise.context.ApplicationScoped;
@@ -45,9 +46,8 @@ public class CallSessionManager {
 
     /**
      * SIP Call-IDs currently being handled, claimed atomically before {@code 180 Ringing} is sent.
-     * Maps SIP Call-ID → Liberty session ID.
      */
-    private final ConcurrentHashMap<String, String> claimedSipCallIds = new ConcurrentHashMap<>();
+    private final Set<String> claimedSipCallIds = ConcurrentHashMap.newKeySet();
 
     /**
      * Language selections written by the DTMF dispatcher; read (and cleared) by the menu runner
@@ -56,13 +56,13 @@ public class CallSessionManager {
     private final ConcurrentHashMap<String, LanguageFactory> pendingSelections = new ConcurrentHashMap<>();
 
     /**
-     * Atomically claims a SIP Call-ID for the given Liberty session.
+     * Atomically claims a SIP Call-ID.
      * Returns {@code true} if the claim succeeded (no other session was already handling this
      * Call-ID), or {@code false} if the Call-ID was already claimed — indicating a duplicate
      * INVITE fork that should be rejected.
      */
-    boolean tryClaimSipCallId(String sipCallId, String sessionId) {
-        return this.claimedSipCallIds.putIfAbsent(sipCallId, sessionId) == null;
+    boolean tryClaimSipCallId(String sipCallId) {
+        return this.claimedSipCallIds.add(sipCallId);
     }
 
     /** Releases a previously claimed SIP Call-ID. */
@@ -120,14 +120,12 @@ public class CallSessionManager {
                 "{0}BYE received from [{1}]",
                 SipCallHeaders.callPrefix(sessionId),
                 req.getFrom());
-        CallState callState = this.activeCalls.remove(sessionId);
+        CallState callState = this.remove(sessionId);
 
         if (callState == null) {
             req.createResponse(SipServletResponse.SC_OK).send();
             return;
         }
-
-        releaseSipCallId(callState.sipCallId());
 
         callState.callFuture().cancel(true);
         callState.receiverFuture().cancel(true);

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallState.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallState.java
@@ -24,8 +24,13 @@ import javax.servlet.sip.SipSession;
  *
  * <p>Stored in {@link CallSessionManager} and accessed by all handler beans that need to
  * cancel futures, close media, or determine which language was selected.
+ *
+ * <p>{@code sipCallId} is the SIP {@code Call-ID} header value, used to detect and reject
+ * duplicate INVITE forks from the provider before they result in two active sessions for the
+ * same logical call.
  */
 record CallState(
+        String sipCallId,
         SipSession session,
         Future<?> callFuture,
         Future<?> receiverFuture,

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManagerTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManagerTest.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.war.listener;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+class CallSessionManagerTest {
+
+    @Test
+    void tryClaimSipCallId_firstForkSucceeds() {
+        // given
+        var manager = new CallSessionManager();
+
+        // when
+        boolean claimed = manager.tryClaimSipCallId("call-id-1", "wlp_2_2");
+
+        // then
+        assertTrue(claimed);
+    }
+
+    @Test
+    void tryClaimSipCallId_duplicateForkIsRejected() {
+        // given
+        var manager = new CallSessionManager();
+        manager.tryClaimSipCallId("call-id-1", "wlp_2_2");
+
+        // when — second fork with the same SIP Call-ID
+        boolean claimed = manager.tryClaimSipCallId("call-id-1", "wlp_3_3");
+
+        // then
+        assertFalse(claimed);
+    }
+
+    @Test
+    void tryClaimSipCallId_differentCallIdsAreIndependent() {
+        // given
+        var manager = new CallSessionManager();
+        manager.tryClaimSipCallId("call-id-1", "wlp_2_2");
+
+        // when — a different call (different SIP Call-ID)
+        boolean claimed = manager.tryClaimSipCallId("call-id-2", "wlp_4_4");
+
+        // then
+        assertTrue(claimed);
+    }
+
+    @Test
+    void releaseSipCallId_allowsReclaimAfterRelease() {
+        // given
+        var manager = new CallSessionManager();
+        manager.tryClaimSipCallId("call-id-1", "wlp_2_2");
+        manager.releaseSipCallId("call-id-1");
+
+        // when — next call with the same SIP Call-ID (e.g. caller rings again)
+        boolean claimed = manager.tryClaimSipCallId("call-id-1", "wlp_6_6");
+
+        // then
+        assertTrue(claimed);
+    }
+}

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManagerTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManagerTest.java
@@ -25,7 +25,7 @@ class CallSessionManagerTest {
         var manager = new CallSessionManager();
 
         // when
-        boolean claimed = manager.tryClaimSipCallId("call-id-1", "wlp_2_2");
+        boolean claimed = manager.tryClaimSipCallId("call-id-1");
 
         // then
         assertTrue(claimed);
@@ -35,10 +35,10 @@ class CallSessionManagerTest {
     void tryClaimSipCallId_duplicateForkIsRejected() {
         // given
         var manager = new CallSessionManager();
-        manager.tryClaimSipCallId("call-id-1", "wlp_2_2");
+        manager.tryClaimSipCallId("call-id-1");
 
         // when — second fork with the same SIP Call-ID
-        boolean claimed = manager.tryClaimSipCallId("call-id-1", "wlp_3_3");
+        boolean claimed = manager.tryClaimSipCallId("call-id-1");
 
         // then
         assertFalse(claimed);
@@ -48,10 +48,10 @@ class CallSessionManagerTest {
     void tryClaimSipCallId_differentCallIdsAreIndependent() {
         // given
         var manager = new CallSessionManager();
-        manager.tryClaimSipCallId("call-id-1", "wlp_2_2");
+        manager.tryClaimSipCallId("call-id-1");
 
         // when — a different call (different SIP Call-ID)
-        boolean claimed = manager.tryClaimSipCallId("call-id-2", "wlp_4_4");
+        boolean claimed = manager.tryClaimSipCallId("call-id-2");
 
         // then
         assertTrue(claimed);
@@ -61,11 +61,11 @@ class CallSessionManagerTest {
     void releaseSipCallId_allowsReclaimAfterRelease() {
         // given
         var manager = new CallSessionManager();
-        manager.tryClaimSipCallId("call-id-1", "wlp_2_2");
+        manager.tryClaimSipCallId("call-id-1");
         manager.releaseSipCallId("call-id-1");
 
         // when — next call with the same SIP Call-ID (e.g. caller rings again)
-        boolean claimed = manager.tryClaimSipCallId("call-id-1", "wlp_6_6");
+        boolean claimed = manager.tryClaimSipCallId("call-id-1");
 
         // then
         assertTrue(claimed);

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
@@ -61,8 +61,8 @@ class HoldHandlerTest {
         String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=sendrecv\r\n";
         AtomicBoolean held = new AtomicBoolean(false);
         CallMedia media = new CallMedia(null, null, sdpAnswer, null, -1, held);
-        CallState callState =
-                new CallState(sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
+        CallState callState = new CallState(
+                "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-1");
         when(req.getSession()).thenReturn(sipSession);
         when(req.getContent()).thenReturn(sdpOffer.getBytes(StandardCharsets.UTF_8));
@@ -88,8 +88,8 @@ class HoldHandlerTest {
         String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=sendrecv\r\n";
         AtomicBoolean held = new AtomicBoolean(false);
         CallMedia media = new CallMedia(null, null, sdpAnswer, null, -1, held);
-        CallState callState =
-                new CallState(sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
+        CallState callState = new CallState(
+                "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-2");
         when(req.getSession()).thenReturn(sipSession);
         when(req.getContent()).thenReturn(sdpOffer.getBytes(StandardCharsets.UTF_8));
@@ -115,8 +115,8 @@ class HoldHandlerTest {
         String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=recvonly\r\n";
         AtomicBoolean held = new AtomicBoolean(true);
         CallMedia media = new CallMedia(null, null, sdpAnswer, null, -1, held);
-        CallState callState =
-                new CallState(sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
+        CallState callState = new CallState(
+                "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-3");
         when(req.getSession()).thenReturn(sipSession);
         when(req.getContent()).thenReturn(sdpOffer.getBytes(StandardCharsets.UTF_8));


### PR DESCRIPTION
## Problem

Telekom's IMS routes every incoming INVITE over **two parallel TCP paths simultaneously** (SIP call forking).
Both forks carry the **same SIP Call-ID** but different `Via` branch parameters and different remote RTP endpoints from two media-proxy servers.

The app was accepting both forks and answering each with `200 OK`.
Telekom's SBC received two 200 OKs for one logical call and immediately sent `BYE` to both legs — causing every Telekom call to disconnect within ~40 ms with `duration=0s` and no audio heard.

Evidence from `last-trace.log` (2026-04-22):
```
19:51:08.450 INVITE wlp_2_2 — Call-ID p65539t…s2, remote RTP 217.0.170.37:22214
19:51:08.457 INVITE wlp_3_3 — Call-ID p65539t…s2, remote RTP 217.0.170.38:34860  (7 ms later)
19:51:09.830 200 OK  wlp_3_3
19:51:09.841 200 OK  wlp_2_2
19:51:09.866 BYE     wlp_3_3  (39 ms after 200 OK)  duration=0s
19:51:09.877 BYE     wlp_2_2
```

## Fix

Before sending `180 Ringing`, `CallSessionManager.tryClaimSipCallId()` atomically claims the SIP Call-ID using `ConcurrentHashMap.putIfAbsent()`.
The second fork fails the claim and receives `486 Busy Here`, so only one session is established per call.

The claim is released in every teardown path:
- `handleBye()` — normal call end via BYE
- `remove()` — announcement or menu playback completes normally
- `processAcceptedInvite()` error paths — IOException or interrupt during setup
- `onShutdown()` — Liberty container shutdown

## Testing

Four unit tests added to `CallSessionManagerTest`:
- First fork succeeds
- Duplicate fork with same Call-ID is rejected
- Different Call-IDs are independent (concurrent calls still work)
- Release allows a re-claim (same number rings again after hang-up)