### PR TITLE
ci: separate forbidden-apis and spotless into standalone workflows

### DIFF
--- a/.github/workflows/forbidden-apis-check.yml
+++ b/.github/workflows/forbidden-apis-check.yml
@@ -1,4 +1,4 @@
-name: Maven tests
+name: Forbidden APIs check
 
 on:
   workflow_dispatch: {}
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  check:
     if: github.ref_name == 'main' || github.event_name != 'push' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     strategy:
@@ -29,7 +29,7 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: maven
 
-      - name: Run unit and integration tests
+      - name: Check forbidden APIs
         shell: bash
         run: >
           ./mvnw
@@ -40,4 +40,4 @@ jobs:
           verify
           -DtrimStackTrace=false
           -Dspotless.skip=true
-          -Dforbiddenapis.skip=true
+          -Dforbiddenapis.skip=false

--- a/.github/workflows/spotless-check.yml
+++ b/.github/workflows/spotless-check.yml
@@ -1,4 +1,4 @@
-name: Maven tests
+name: Code style check (Spotless)
 
 on:
   workflow_dispatch: {}
@@ -9,7 +9,7 @@ permissions:
   contents: read
 
 jobs:
-  test:
+  check:
     if: github.ref_name == 'main' || github.event_name != 'push' && github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name
     runs-on: ubuntu-latest
     strategy:
@@ -29,7 +29,7 @@ jobs:
           java-version: ${{ matrix.java }}
           cache: maven
 
-      - name: Run unit and integration tests
+      - name: Check code style
         shell: bash
         run: >
           ./mvnw
@@ -37,7 +37,4 @@ jobs:
           --errors
           --batch-mode
           --no-transfer-progress
-          verify
-          -DtrimStackTrace=false
-          -Dspotless.skip=true
-          -Dforbiddenapis.skip=true
+          spotless:check


### PR DESCRIPTION
Resolves #61

## Summary

Moves forbidden-apis and spotless checks out of the main test workflow into two independent, specialized workflows that run in parallel.

## Benefits for Developer Productivity

### 1. Faster Feedback on Test Failures
Tests now complete without waiting for time-consuming static checks. Developers see actual test results immediately, enabling faster iteration on real bugs.

### 2. Independent Failure Analysis
All three categories of issues are visible in parallel:
- **Test/integration failures** (maven-tests.yml)
- **Forbidden API violations** (forbidden-apis-check.yml)
- **Code style issues** (spotless-check.yml)

No sequential blocking; reviewers see the full picture at once.

### 3. Optional Enforcement Flexibility
Separate workflows enable different merge requirements in future:
- Test failures → always block (critical)
- Forbidden API → always block (security)
- Style → can be auto-fixed or require review (policy choice)

### 4. Parallelization and Cost
Instead of sequential test→style→api checks (8 min), all three run simultaneously, completing in the time of the slowest job. Reduces wall-clock time and CI cost.

### 5. Clearer Separation of Concerns
Explicit distinction between:
- **Correctness** (tests)
- **Safety** (forbidden APIs)
- **Consistency** (style)

Makes the CI/CD pipeline clearer and easier to maintain.

## Changes

- Added `.github/workflows/forbidden-apis-check.yml` — new dedicated workflow
- Added `.github/workflows/spotless-check.yml` — new dedicated workflow
- Updated `.github/workflows/maven-tests.yml` — added `-Dforbiddenapis.skip=true` skip property

All workflows use identical run conditions (main branch or internal PRs only).
