### PR TITLE
fix: remove redundant 1s sleep from menu announcement playback task

### DIFF
--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
@@ -221,6 +221,11 @@ public class CallAcceptor {
         LinkedHashMap<Integer, LanguageFactory> singleMenu = new LinkedHashMap<>();
         singleMenu.put(1, factory);
 
+        // CRITICAL: Do NOT add a sleep/delay here.
+        // The 1-second ringing delay already happened in the INVITE handler thread (line 168)
+        // before 200 OK was sent. Audio playback must begin immediately after 200 OK
+        // so RTP arrives within the endpoint's audio-delivery window (~1-2s).
+        // Adding post-answer delays causes audio dropout on many SIP endpoints.
         Future<?> callFuture = this.managedExecutorService.submit(() -> {
             // forCall() must run on the announcement thread so that the confined Arena is owned
             // by the thread that will also call encode() and close() — preventing WrongThreadException.
@@ -262,14 +267,12 @@ public class CallAcceptor {
                 SipCallHeaders.callPrefix(sessionId),
                 callerIdentitySummary);
 
+        // CRITICAL: Do NOT add a sleep/delay here.
+        // The 1-second ringing delay already happened in the INVITE handler thread (line 168)
+        // before 200 OK was sent. Audio playback must begin immediately after 200 OK
+        // so RTP arrives within the endpoint's audio-delivery window (~1-2s).
+        // Adding post-answer delays causes audio dropout on many SIP endpoints.
         Future<?> callFuture = this.managedExecutorService.submit(() -> {
-            try {
-                Thread.sleep(1_000);
-            } catch (InterruptedException interruptedException) {
-                Thread.currentThread().interrupt();
-                return;
-            }
-
             // forCall() must run on the menu thread so that the confined Arena is owned
             // by the thread that will also call encode() and close() — preventing WrongThreadException.
             var callCodec = media.codec().forCall();


### PR DESCRIPTION
## Problem

After PR #78 merged, multi-language calls have audio dropout. Single-language calls work fine.

Root cause: A redundant 1-second `Thread.sleep()` was added to the menu announcement playback task (line 267 in `acceptAndPlayMenu`). Combined with the pre-answer ringing delay that now happens in the INVITE handler thread, this created a 2-second total delay:

1. INVITE handler: `sleep(1_000)` → send 180 Ringing → send 200 OK
2. Playback task: `sleep(1_000)` → `forCall()` → start audio

The excessive post-answer delay caused audio delivery to fail or be severely delayed on many endpoints.

## Solution

Remove the redundant sleep from line 267 in `acceptAndPlayMenu()`. The 1-second ringing delay already happens before 200 OK is sent, so the playback task should start immediately after.

After this fix:
1. INVITE handler: `sleep(1_000)` → 180 Ringing → 200 OK (ringing UX)
2. Playback task: immediately → `forCall()` → audio (no additional delay)

Consistent with single-language path (`acceptAndAnnounce()`) which had correct logic.

## Verification

- Build passes with all tests green
- Both single-language and multi-language paths now have consistent timing
- Single-language path (which worked) has no sleep in playback task
- Menu path now matches this behavior

Related to #78 (ringing delay restoration).
