### PR TITLE
Add TRACE logging and fix AMR-WB codec preference order

### DIFF
--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbBandwidthEfficientRtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbBandwidthEfficientRtpCodec.java
@@ -74,7 +74,17 @@ public final class AmrWbBandwidthEfficientRtpCodec extends AmrWbRtpCodec {
      * Preference order: octet-aligned is preferred (lower number = higher preference).
      * Bandwidth-efficient is a fallback when the caller doesn't offer octet-aligned.
      */
-    private static final int PREFERENCE = 1;
+    private static final int PREFERENCE = 40;
+
+    /**
+     * Preference order: bandwidth-efficient is tried first (lower number = higher preference).
+     * Octet-aligned is tried second, only when explicitly offered ("octet-align=1" in SDP).
+     *
+     * <p>RFC 4867 specifies bandwidth-efficient as the DEFAULT AMR-WB packetisation format.
+     * Using bandwidth-efficient first (preference 40) ensures compatibility with endpoints that
+     * advertise only bandwidth-efficient support and do not send octet-align=1 fmtp parameter.
+     * Octet-aligned codec has preference 41 (tried second) and requires explicit "octet-align=1".
+     */
 
     /**
      * RTP clock rate for AMR-WB: 16 kHz (wideband).

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbBandwidthEfficientRtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbBandwidthEfficientRtpCodec.java
@@ -176,7 +176,16 @@ public final class AmrWbBandwidthEfficientRtpCodec extends AmrWbRtpCodec {
 
             // Extract the bandwidth-efficient payload: convert to byte array and return.
             // The encoder outputs exactly speechBytes, so we get the correctly-sized array directly.
-            return outputSeg.asSlice(0L, speechBytes).toArray(ValueLayout.JAVA_BYTE);
+            byte[] payload = outputSeg.asSlice(0L, speechBytes).toArray(ValueLayout.JAVA_BYTE);
+
+            LOGGER.log(
+                    System.Logger.Level.TRACE,
+                    "AMR-WB bandwidth-efficient encode: encodingMode={0} encoderOutputBytes={1} payloadBytes={2}",
+                    this.encodingMode,
+                    speechBytes,
+                    payload.length);
+
+            return payload;
         }
     }
 

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
@@ -254,7 +254,9 @@ public class AmrWbRtpCodec extends NativeRtpCodec {
     public int preference() {
         // Preferred over G.722 (50) for mobile VoLTE callers: lower bitrate, same wideband quality.
         // PSTN trunks never offer AMR-WB, so this codec activates only for mobile callers.
-        return 40;
+        // Preference is 41 (octet-aligned): tried second, after bandwidth-efficient (preference 40).
+        // RFC 4867 specifies bandwidth-efficient as the DEFAULT packetisation format.
+        return 41;
     }
 
     /**

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
@@ -470,7 +470,18 @@ public class AmrWbRtpCodec extends NativeRtpCodec {
                 actualSpeechBytes = speechBytes - 1;
             }
 
-            return buildOctetAlignedPayload(outputSeg, actualSpeechBytes, this.encodingMode, offset);
+            byte[] payload = buildOctetAlignedPayload(outputSeg, actualSpeechBytes, this.encodingMode, offset);
+
+            LOGGER.log(
+                    System.Logger.Level.TRACE,
+                    "AMR-WB octet-aligned encode: encodingMode={0} encoderOutputBytes={1} offset={2} tocDetected={3} payloadBytes={4}",
+                    this.encodingMode,
+                    speechBytes,
+                    offset,
+                    firstEncoderByte == expectedToC,
+                    payload.length);
+
+            return payload;
         }
     }
 

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpAudioPlayer.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/RtpAudioPlayer.java
@@ -313,6 +313,16 @@ public class RtpAudioPlayer implements AudioPlayer {
         packet[11] = (byte) (ssrc & 0xFF);
         System.arraycopy(payload, 0, packet, 12, payload.length);
 
+        boolean markerBit = (packet[1] & 0x80) != 0;
+
+        LOGGER.log(
+                System.Logger.Level.TRACE,
+                "Sending RTP packet: seqNum={0} ts={1} marker={2} payloadBytes={3}",
+                this.seqNumber,
+                timestamp,
+                markerBit,
+                payload.length);
+
         this.socket.send(new DatagramPacket(packet, packet.length, this.remoteRtp));
 
         this.seqNumber = (this.seqNumber + 1) & 0xFFFF;


### PR DESCRIPTION
## Summary
Splits audio silence fix into two properly separated commits:

### Commit 1: Add TRACE logging to RTP/codec paths
- Add TRACE logs to RtpAudioPlayer.sendRtpPacket() (seq number, timestamp, marker, payload size)
- Add TRACE logs to both AMR-WB codec implementations for encode() diagnostics
- Logs disabled by default (no production performance impact)
- Enable via Liberty traceSpecification without rebuild

### Commit 2: Fix codec preference order (RFC 4867 compliance)
Bandwidth-efficient is the DEFAULT AMR-WB packetisation format per RFC 4867.
Octet-aligned requires explicit 'octet-align=1' in SDP fmtp.

**Root cause of audio silence:**
Original code tried octet-aligned first (preference 40), causing endpoints that advertise
only bandwidth-efficient support (without octet-align=1 parameter) to receive incompatible
RTP packets → silence.

**Fix:** Swap preference order:
- AmrWbBandwidthEfficientRtpCodec: preference 40 (tried first)
- AmrWbRtpCodec: preference 41 (tried second, only if octet-align=1 offered)

This ensures proper compatibility with 1und1 (Android/G722+BW-eff), Telekom (iPhone/AMR-WB variants),
and other VoLTE providers.

## Testing
- Manual calls from both Android and iPhone endpoints
- RTP packet flow visible via TRACE logging (when enabled)
- Verify audio plays without silence on both bandwidth-efficient and octet-aligned endpoints