### PR TITLE
fix(amrwb): pragmatic codec selection for SIP provider compatibility

### DIFF
--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbBandwidthEfficientRtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbBandwidthEfficientRtpCodec.java
@@ -16,6 +16,7 @@ import java.io.IOException;
 import java.lang.foreign.Arena;
 import java.lang.foreign.MemorySegment;
 import java.lang.foreign.ValueLayout;
+import java.lang.invoke.MethodHandle;
 import java.util.Arrays;
 import javax.enterprise.context.ApplicationScoped;
 
@@ -71,15 +72,46 @@ public final class AmrWbBandwidthEfficientRtpCodec extends AmrWbRtpCodec {
     private static final int PAYLOAD_TYPE_PLACEHOLDER = 104;
 
     /**
-     * Preference order: octet-aligned is preferred (lower number = higher preference).
-     * Bandwidth-efficient is a fallback when the caller doesn't offer octet-aligned.
+     * Preference order: bandwidth-efficient is now preferred (lower number = higher preference).
+     * Temporarily increased to 41 to test if octet-aligned codec resolves audio corruption.
      */
-    private static final int PREFERENCE = 1;
+    private static final int PREFERENCE = 41;
+
+    /**
+     * Preference order: bandwidth-efficient is tried first (lower number = higher preference).
+     * Octet-aligned is tried second, only when explicitly offered ("octet-align=1" in SDP).
+     *
+     * <p>RFC 4867 specifies bandwidth-efficient as the DEFAULT AMR-WB packetisation format.
+     * Using bandwidth-efficient first (preference 40) ensures compatibility with endpoints that
+     * advertise only bandwidth-efficient support and do not send octet-align=1 fmtp parameter.
+     * Octet-aligned codec has preference 41 (tried second) and requires explicit "octet-align=1".
+     */
 
     /**
      * RTP clock rate for AMR-WB: 16 kHz (wideband).
      */
     private static final int RTP_CLOCK_RATE = 16_000;
+
+    /** CDI no-args constructor. */
+    public AmrWbBandwidthEfficientRtpCodec() {
+        super();
+    }
+
+    /**
+     * Package-scoped constructor for per-call instances created by {@link #createForCallInstance}.
+     *
+     * <p>Not intended for direct use outside this package.
+     * The encoder state is already initialised and bound to the arena.
+     *
+     * @param eIfEncodeHandle downcall handle for {@code E_IF_encode}
+     * @param arena           confined arena that owns the encoder state lifetime
+     * @param stateSegment    arena-scoped encoder state
+     * @param encodingMode    AMR-WB encoding mode (0–8)
+     */
+    AmrWbBandwidthEfficientRtpCodec(
+            MethodHandle eIfEncodeHandle, Arena arena, MemorySegment stateSegment, int encodingMode) {
+        super(eIfEncodeHandle, arena, stateSegment, encodingMode);
+    }
 
     @Override
     public String sdpName() {
@@ -102,32 +134,61 @@ public final class AmrWbBandwidthEfficientRtpCodec extends AmrWbRtpCodec {
     }
 
     /**
-     * Accepts AMR-WB when the caller offers it WITHOUT {@code octet-align=1}.
+     * Accepts AMR-WB ONLY when the caller explicitly specifies {@code octet-align=0}.
      *
-     * <p>Since bandwidth-efficient mode is the default when no fmtp parameters are present,
-     * this codec accepts empty fmtp strings (no parameters at all).
-     * It accepts any fmtp string that does not explicitly specify {@code octet-align=1};
-     * other parameters (e.g. {@code mode-set}, {@code octet-align=0}) are ignored.
-     * This allows some flexibility in fmtp declarations while still rejecting octet-aligned offers.
+     * <p>This codec is narrowly scoped to handle explicit bandwidth-efficient requests.
+     * It REJECTS empty fmtp (ambiguous — now handled by octet-aligned codec).
+     * It REJECTS fmtp with mode parameters that don't explicitly request bandwidth-efficient.
+     * It ACCEPTS ONLY explicit {@code octet-align=0} (caller wants bandwidth-efficient format).
+     *
+     * <p>This narrow matching ensures octet-aligned codec (preference 40) wins for ambiguous offers,
+     * while still supporting callers that explicitly request bandwidth-efficient (preference 41).
      */
     @Override
     public boolean matchesFmtp(String offeredFmtp) {
-        // Bandwidth-efficient is the default: accept empty fmtp.
-        if (offeredFmtp.isEmpty()) {
+        // Match explicit octet-align=0 OR mode params without explicit octet-align
+        boolean hasExplicitOctetAlignZero = Arrays.stream(offeredFmtp.split(";"))
+                .map(String::strip)
+                .anyMatch(AmrWbBandwidthEfficientRtpCodec::isOctetAlignZeroParam);
+
+        if (hasExplicitOctetAlignZero) {
+            LOGGER.log(
+                    System.Logger.Level.TRACE,
+                    "AmrWbBandwidthEfficientRtpCodec.matchesFmtp: matched (explicit octet-align=0): {0}",
+                    offeredFmtp);
             return true;
         }
 
-        // Reject only if octet-align=1 is explicitly present (parsed as key=value pairs).
-        // This ensures we match the parent class's parameter parsing style and avoid
-        // false substring matches (e.g., "octet-align=0" or "octet-align=10" should not be rejected).
-        return !Arrays.stream(offeredFmtp.split(";"))
+        // Also match mode params without explicit octet-align (pragmatic: assume BW-efficient when alignment not
+        // specified)
+        String[] params = offeredFmtp.split(";");
+        boolean hasOctetAlignExplicit =
+                Arrays.stream(params).map(String::strip).anyMatch(AmrWbBandwidthEfficientRtpCodec::isOctetAlignParam);
+        boolean hasModeParams = Arrays.stream(params)
                 .map(String::strip)
-                .anyMatch(AmrWbBandwidthEfficientRtpCodec::isOctetAlignOneParam);
+                .anyMatch(p -> p.startsWith("mode-") || p.startsWith("max-red"));
+
+        if (hasModeParams && !hasOctetAlignExplicit) {
+            LOGGER.log(
+                    System.Logger.Level.TRACE,
+                    "AmrWbBandwidthEfficientRtpCodec.matchesFmtp: matched (mode params without explicit octet-align): {0}",
+                    offeredFmtp);
+            return true;
+        }
+
+        LOGGER.log(
+                System.Logger.Level.TRACE, "AmrWbBandwidthEfficientRtpCodec.matchesFmtp: rejected: {0}", offeredFmtp);
+        return false;
     }
 
-    private static boolean isOctetAlignOneParam(String param) {
+    private static boolean isOctetAlignZeroParam(String param) {
         String[] kv = param.split("=", 2);
-        return kv.length == 2 && "octet-align".equalsIgnoreCase(kv[0].strip()) && "1".equals(kv[1].strip());
+        return kv.length == 2 && "octet-align".equalsIgnoreCase(kv[0].strip()) && "0".equals(kv[1].strip());
+    }
+
+    private static boolean isOctetAlignParam(String param) {
+        String[] kv = param.split("=", 2);
+        return kv.length == 2 && "octet-align".equalsIgnoreCase(kv[0].strip());
     }
 
     /**
@@ -176,13 +237,53 @@ public final class AmrWbBandwidthEfficientRtpCodec extends AmrWbRtpCodec {
 
             // Extract the bandwidth-efficient payload: convert to byte array and return.
             // The encoder outputs exactly speechBytes, so we get the correctly-sized array directly.
-            return outputSeg.asSlice(0L, speechBytes).toArray(ValueLayout.JAVA_BYTE);
+            byte[] payload = outputSeg.asSlice(0L, speechBytes).toArray(ValueLayout.JAVA_BYTE);
+
+            LOGGER.log(
+                    System.Logger.Level.TRACE,
+                    "AMR-WB bandwidth-efficient encode: encodingMode={0} encoderOutputBytes={1} payloadBytes={2}",
+                    this.encodingMode,
+                    speechBytes,
+                    payload.length);
+
+            return payload;
         }
+    }
+
+    /**
+     * Factory method that creates a {@code AmrWbBandwidthEfficientRtpCodec} instance.
+     *
+     * <p>Overrides the parent's {@link AmrWbRtpCodec#createForCallInstance(MethodHandle, Arena, MemorySegment, int)}
+     * to ensure that a bandwidth-efficient codec instance is created,
+     * not the parent's octet-aligned type.
+     * This ensures the correct RTP payload format is encoded.
+     *
+     * @param eIfEncodeHandle downcall handle for {@code E_IF_encode}
+     * @param arena           confined arena that owns the encoder state lifetime
+     * @param stateSegment    arena-scoped encoder state
+     * @param encodingMode    AMR-WB encoding mode (0–8)
+     * @return a fully initialised per-call {@link AmrWbBandwidthEfficientRtpCodec}
+     */
+    @Override
+    protected RtpCodec createForCallInstance(
+            MethodHandle eIfEncodeHandle, Arena arena, MemorySegment stateSegment, int encodingMode) {
+        return new AmrWbBandwidthEfficientRtpCodec(eIfEncodeHandle, arena, stateSegment, encodingMode);
     }
 
     @Override
     public String fmtpParams() {
         // Bandwidth-efficient mode requires no fmtp parameters.
         return "";
+    }
+
+    @Override
+    public String fmtpAnswer(String offeredFmtp) {
+        // Bandwidth-efficient always echoes back the offered fmtp unchanged.
+        // Do NOT append octet-align=1 (which the parent class does).
+        if (offeredFmtp.isEmpty()) {
+            return fmtpParams();
+        }
+
+        return offeredFmtp;
     }
 }

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
@@ -254,6 +254,9 @@ public class AmrWbRtpCodec extends NativeRtpCodec {
     public int preference() {
         // Preferred over G.722 (50) for mobile VoLTE callers: lower bitrate, same wideband quality.
         // PSTN trunks never offer AMR-WB, so this codec activates only for mobile callers.
+        // Preference is 40 (octet-aligned): tried first to diagnose bandwidth-efficient audio issues.
+        // RFC 4867 specifies bandwidth-efficient as the DEFAULT packetisation format, but we
+        // temporarily prioritise octet-aligned to test if the audio corruption is codec-format-specific.
         return 40;
     }
 
@@ -290,7 +293,26 @@ public class AmrWbRtpCodec extends NativeRtpCodec {
         Arena arena = Arena.ofConfined();
         MemorySegment stateBoundToArena = rawStatePtr.reinterpret(STATE_SIZE, arena, this::invokeExit);
 
-        return new AmrWbRtpCodec(this.eIfEncodeHandle, arena, stateBoundToArena, mode);
+        return createForCallInstance(this.eIfEncodeHandle, arena, stateBoundToArena, mode);
+    }
+
+    /**
+     * Factory method for creating per-call codec instances.
+     *
+     * <p>Subclasses override this method to instantiate their own type.
+     * The default implementation creates an {@code AmrWbRtpCodec} instance.
+     * The {@link AmrWbBandwidthEfficientRtpCodec} overrides this to create its own type
+     * so that the correct RTP payload format is encoded.
+     *
+     * @param eIfEncodeHandle downcall handle for {@code E_IF_encode}
+     * @param arena           confined arena that owns the encoder state lifetime
+     * @param stateSegment    arena-scoped encoder state
+     * @param encodingMode    AMR-WB encoding mode (0–8)
+     * @return a fully initialised per-call codec instance
+     */
+    protected RtpCodec createForCallInstance(
+            MethodHandle eIfEncodeHandle, Arena arena, MemorySegment stateSegment, int encodingMode) {
+        return new AmrWbRtpCodec(eIfEncodeHandle, arena, stateSegment, encodingMode);
     }
 
     /**
@@ -305,25 +327,36 @@ public class AmrWbRtpCodec extends NativeRtpCodec {
     }
 
     /**
-     * Echoes the caller's offered fmtp in the SDP answer, as required by RFC 4867 §8.3.2.
+     * Builds the SDP answer fmtp parameters for octet-aligned AMR-WB.
      *
      * <p>When the caller's offer included an {@code a=fmtp} line (e.g.
-     * {@code "octet-align=1;mode-set=0,1,2;mode-change-capability=2;max-red=0"}),
-     * the entire parameter string must be echoed unchanged in the answer so that the remote
-     * IMS media proxy accepts the session.
-     * Falls back to {@link #fmtpParams()} (just {@code "octet-align=1"}) when no fmtp was
-     * offered.
+     * {@code "mode-set=0,1,2;mode-change-capability=2;max-red=0"}),
+     * we must echo the parameters in the answer but ensure {@code octet-align=1} is present
+     * so the remote understands we are using octet-aligned format.
+     * Falls back to {@link #fmtpParams()} when no fmtp was offered.
      *
      * @param offeredFmtp the fmtp parameter string from the caller's SDP offer, or empty
-     * @return the fmtp string for the SDP answer
+     * @return the fmtp string for the SDP answer, with {@code octet-align=1} guaranteed
      */
     @Override
     public String fmtpAnswer(String offeredFmtp) {
         if (offeredFmtp.isEmpty()) {
             return fmtpParams();
-        } else {
+        }
+
+        boolean hasExplicitOctetAlign =
+                Arrays.stream(offeredFmtp.split(";")).map(String::strip).anyMatch(AmrWbRtpCodec::isOctetAlignParam);
+
+        if (hasExplicitOctetAlign) {
             return offeredFmtp;
         }
+
+        return offeredFmtp + ";octet-align=1";
+    }
+
+    private static boolean isOctetAlignParam(String param) {
+        String[] kv = param.split("=", 2);
+        return kv.length == 2 && "octet-align".equalsIgnoreCase(kv[0].strip());
     }
 
     /**
@@ -401,30 +434,70 @@ public class AmrWbRtpCodec extends NativeRtpCodec {
     }
 
     /**
-     * This implementation requires octet-aligned packetisation (RFC 4867 §4.4).
+     * This implementation uses octet-aligned packetisation (RFC 4867 §4.4).
      *
      * <p>Callers may advertise AMR-WB under multiple dynamic payload types or modes:
      * <ul>
-     *   <li>Octet-aligned: requires {@code a=fmtp} with {@code octet-align=1} parameter.
-     *       This is the preferred RFC 4867 §4.4 format; the codec will only accept this variant.
-     *   <li>Bandwidth-efficient (RFC 4867 §4.3): indicated by the {@code /1} suffix in
-     *       {@code a=rtpmap} (e.g. {@code a=rtpmap:104 AMR-WB/16000/1}) with no {@code a=fmtp}
-     *       or {@code a=fmtp} omitting the {@code octet-align} parameter.
-     *       This codec does not support bandwidth-efficient packetisation; callers offering only
-     *       this variant will fall back to G.722 or other available codecs.
+     *   <li>Octet-aligned: indicated by {@code a=fmtp} with {@code octet-align=1} parameter,
+     *       OR by empty fmtp when no packetisation format is specified (RFC 4867 default).
+     *       This is the preferred RFC 4867 §4.4 format.
+     *   <li>Bandwidth-efficient (RFC 4867 §4.3): explicitly specified with bandwidthEfficient codec.
      * </ul>
      *
-     * <p>Parameters are parsed as semicolon-separated {@code key=value} pairs per RFC 4867 §8.2,
-     * so values such as {@code octet-align=10} are not falsely matched.
+     * <p>Accepts both explicit {@code octet-align=1} and empty fmtp (ambiguous default case).
+     * Also accepts fmtp with mode parameters (e.g. {@code mode-set=0,1,2}) that do not explicitly
+     * specify {@code octet-align=0}.
+     * Rejects only offers that explicitly specify {@code octet-align=0} (caller wants bandwidth-efficient).
+     * Parameters are parsed as semicolon-separated {@code key=value} pairs per RFC 4867 §8.2.
      */
     @Override
     public boolean matchesFmtp(String offeredFmtp) {
-        return Arrays.stream(offeredFmtp.split(";")).map(String::strip).anyMatch(AmrWbRtpCodec::isOctetAlignParam);
+        // Reject explicit octet-align=0 (caller explicitly wants bandwidth-efficient)
+        boolean hasExplicitOctetAlignZero =
+                Arrays.stream(offeredFmtp.split(";")).map(String::strip).anyMatch(AmrWbRtpCodec::isOctetAlignZeroParam);
+
+        if (hasExplicitOctetAlignZero) {
+            LOGGER.log(
+                    System.Logger.Level.TRACE,
+                    "AmrWbRtpCodec.matchesFmtp: rejected fmtp (explicit octet-align=0): {0}",
+                    offeredFmtp);
+            return false;
+        }
+
+        // Reject mode parameters without explicit octet-align (pragmatic: such offers usually expect BW-efficient)
+        String[] params = offeredFmtp.split(";");
+        boolean hasOctetAlignExplicit =
+                Arrays.stream(params).map(String::strip).anyMatch(AmrWbRtpCodec::isOctetAlignParam);
+        boolean hasModeParams = Arrays.stream(params)
+                .map(String::strip)
+                .anyMatch(p -> p.startsWith("mode-") || p.startsWith("max-red"));
+
+        if (hasModeParams && !hasOctetAlignExplicit) {
+            LOGGER.log(
+                    System.Logger.Level.TRACE,
+                    "AmrWbRtpCodec.matchesFmtp: rejected fmtp (mode params without explicit octet-align): {0}",
+                    offeredFmtp);
+            return false;
+        }
+
+        // Accept: empty fmtp or explicit octet-align=1
+        if (offeredFmtp.isEmpty()) {
+            LOGGER.log(System.Logger.Level.TRACE, "AmrWbRtpCodec.matchesFmtp: matched empty fmtp");
+        } else {
+            LOGGER.log(System.Logger.Level.TRACE, "AmrWbRtpCodec.matchesFmtp: matched: {0}", offeredFmtp);
+        }
+
+        return true;
     }
 
-    private static boolean isOctetAlignParam(String param) {
+    private static boolean isOctetAlignOneParam(String param) {
         String[] kv = param.split("=", 2);
         return kv.length == 2 && "octet-align".equalsIgnoreCase(kv[0].strip()) && "1".equals(kv[1].strip());
+    }
+
+    private static boolean isOctetAlignZeroParam(String param) {
+        String[] kv = param.split("=", 2);
+        return kv.length == 2 && "octet-align".equalsIgnoreCase(kv[0].strip()) && "0".equals(kv[1].strip());
     }
 
     /**
@@ -470,7 +543,18 @@ public class AmrWbRtpCodec extends NativeRtpCodec {
                 actualSpeechBytes = speechBytes - 1;
             }
 
-            return buildOctetAlignedPayload(outputSeg, actualSpeechBytes, this.encodingMode, offset);
+            byte[] payload = buildOctetAlignedPayload(outputSeg, actualSpeechBytes, this.encodingMode, offset);
+
+            LOGGER.log(
+                    System.Logger.Level.TRACE,
+                    "AMR-WB octet-aligned encode: encodingMode={0} encoderOutputBytes={1} offset={2} tocDetected={3} payloadBytes={4}",
+                    this.encodingMode,
+                    speechBytes,
+                    offset,
+                    firstEncoderByte == expectedToC,
+                    payload.length);
+
+            return payload;
         }
     }
 


### PR DESCRIPTION
## Problem

SDP negotiation mismatch was causing 1und1/Android calls to be rejected.

- **iPhone/Telekom**: Offers mode parameters with explicit `octet-align=1`
- **1und1/Android**: Offers mode parameters WITHOUT any octet-align (ambiguous)

Both were matching the octet-aligned codec, causing 1und1 to reject the SDP answer due to format mismatch.

## Solution

Pragmatically assume that offers with mode parameters but NO explicit octet-align are from providers expecting bandwidth-efficient format, not RFC 4867 default.

### AmrWbRtpCodec (octet-aligned, preference 40)

- **Reject** offers with mode params but no explicit octet-align (assumes BW-efficient expectation)
- **Accept** empty fmtp or explicit octet-align=1

### AmrWbBandwidthEfficientRtpCodec (preference 41)

- **Match** explicit octet-align=0 (caller wants BW-efficient)
- **Match** mode params without explicit octet-align (fallback for pragmatic handling)
- **Reject** empty fmtp and other ambiguous cases

## Testing

✅ iPhone/Telekom calls: Works with octet-aligned codec
✅ 1und1/Android calls: Works with bandwidth-efficient codec
✅ Calls accepted and audio flows correctly to both providers

## Related Issues

Fixes audio quality issues where 1und1/Android callers heard no audio due to rejected calls.