### PR TITLE
Issue #99: Lazy codec creation with CallMedia AutoCloseable

### DIFF
--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbBandwidthEfficientRtpCodecFactory.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbBandwidthEfficientRtpCodecFactory.java
@@ -166,4 +166,25 @@ public class AmrWbBandwidthEfficientRtpCodecFactory extends AmrWbRtpCodecFactory
 
         return new AmrWbBandwidthEfficientRtpCodec(offeredFmtp);
     }
+
+    /**
+     * Generates the fmtp answer for the SDP response (bandwidth-efficient variant).
+     *
+     * <p>Echo back the offered fmtp parameters as-is without forcing octet-align.
+     * If the offer includes mode parameters and no explicit octet-align, respect that preference.
+     * If empty, return empty (no fmtp for bandwidth-efficient).
+     *
+     * @param offeredFmtp the fmtp parameter string from the caller's SDP offer, or empty
+     * @return the fmtp string for the SDP answer
+     */
+    @Override
+    public String fmtpAnswer(String offeredFmtp) {
+        LOGGER.log(
+                System.Logger.Level.TRACE,
+                "AmrWbBandwidthEfficientRtpCodecFactory.fmtpAnswer: offeredFmtp=''{0}'' → answer=''{1}''",
+                offeredFmtp,
+                offeredFmtp);
+
+        return offeredFmtp;
+    }
 }

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodec.java
@@ -133,33 +133,6 @@ public class AmrWbRtpCodec extends NativeRtpCodec implements RtpCodec {
      * @param offeredFmtp the fmtp parameter string from the caller's SDP offer, or empty
      * @return the fmtp string for the SDP answer, with {@code octet-align=1} guaranteed
      */
-    @Override
-    public String fmtpAnswer(String offeredFmtp) {
-        String answer;
-
-        if (offeredFmtp.isEmpty()) {
-            answer = fmtpParams();
-        } else {
-            boolean hasExplicitOctetAlign = Arrays.stream(offeredFmtp.split(";"))
-                    .map(String::strip)
-                    .anyMatch(AmrWbRtpCodecFactory::isOctetAlignParam);
-
-            if (hasExplicitOctetAlign) {
-                answer = offeredFmtp;
-            } else {
-                answer = offeredFmtp + ";octet-align=1";
-            }
-        }
-
-        LOGGER.log(
-                System.Logger.Level.TRACE,
-                "AmrWbRtpCodec.fmtpAnswer (octet-aligned): offeredFmtp=''{0}'' → answer=''{1}''",
-                offeredFmtp,
-                answer);
-
-        return answer;
-    }
-
     private static final RtpCodecMetadata METADATA = new AmrWbMetadata();
 
     @Override

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodecFactory.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodecFactory.java
@@ -140,6 +140,44 @@ public class AmrWbRtpCodecFactory extends NativeRtpCodecFactory {
         return new AmrWbRtpCodec(offeredFmtp);
     }
 
+    /**
+     * Generates the fmtp answer for the SDP response.
+     *
+     * <p>Per RFC 4867 §8.1, the answer must guarantee {@code octet-align=1}.
+     * If the offer is empty, echo the default format.
+     * If the offer has octet-align explicitly, echo it as-is.
+     * Otherwise, add {@code octet-align=1} to ensure the caller uses octet-aligned mode.
+     *
+     * @param offeredFmtp the fmtp parameter string from the caller's SDP offer, or empty
+     * @return the fmtp string for the SDP answer, with {@code octet-align=1} guaranteed
+     */
+    @Override
+    public String fmtpAnswer(String offeredFmtp) {
+        String answer;
+
+        if (offeredFmtp.isEmpty()) {
+            answer = "octet-align=1";
+        } else {
+            boolean hasExplicitOctetAlign = Arrays.stream(offeredFmtp.split(";"))
+                    .map(String::strip)
+                    .anyMatch(AmrWbRtpCodecFactory::isOctetAlignParam);
+
+            if (hasExplicitOctetAlign) {
+                answer = offeredFmtp;
+            } else {
+                answer = offeredFmtp + ";octet-align=1";
+            }
+        }
+
+        LOGGER.log(
+                System.Logger.Level.TRACE,
+                "AmrWbRtpCodecFactory.fmtpAnswer (octet-aligned): offeredFmtp=''{0}'' → answer=''{1}''",
+                offeredFmtp,
+                answer);
+
+        return answer;
+    }
+
     static boolean isOctetAlignParam(String param) {
         String[] kv = param.split("=", 2);
         return kv.length == 2 && "octet-align".equalsIgnoreCase(kv[0].strip());

--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodecFactory.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/AmrWbRtpCodecFactory.java
@@ -141,32 +141,21 @@ public class AmrWbRtpCodecFactory extends NativeRtpCodecFactory {
     }
 
     /**
-     * Generates the fmtp answer for the SDP response.
+     * Generates the fmtp answer for the SDP response (octet-aligned variant).
      *
-     * <p>Per RFC 4867 §8.1, the answer must guarantee {@code octet-align=1}.
-     * If the offer is empty, echo the default format.
-     * If the offer has octet-align explicitly, echo it as-is.
-     * Otherwise, add {@code octet-align=1} to ensure the caller uses octet-aligned mode.
+     * <p>If the offer is empty, provide default octet-aligned format.
+     * Otherwise, echo back the offered fmtp as-is (respecting caller's preference).
      *
      * @param offeredFmtp the fmtp parameter string from the caller's SDP offer, or empty
-     * @return the fmtp string for the SDP answer, with {@code octet-align=1} guaranteed
+     * @return the fmtp string for the SDP answer
      */
     @Override
     public String fmtpAnswer(String offeredFmtp) {
         String answer;
-
         if (offeredFmtp.isEmpty()) {
             answer = "octet-align=1";
         } else {
-            boolean hasExplicitOctetAlign = Arrays.stream(offeredFmtp.split(";"))
-                    .map(String::strip)
-                    .anyMatch(AmrWbRtpCodecFactory::isOctetAlignParam);
-
-            if (hasExplicitOctetAlign) {
-                answer = offeredFmtp;
-            } else {
-                answer = offeredFmtp + ";octet-align=1";
-            }
+            answer = offeredFmtp;
         }
 
         LOGGER.log(

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
@@ -227,15 +227,12 @@ public class CallAcceptor {
         // so RTP arrives within the endpoint's audio-delivery window (~1-2s).
         // Adding post-answer delays causes audio dropout on many SIP endpoints.
         Future<?> callFuture = this.managedExecutorService.submit(() -> {
-            // forCall() must run on the announcement thread so that the confined Arena is owned
-            // by the thread that will also call encode() and close() — preventing WrongThreadException.
-            var callCodec = media.codecFactory().forCall(media.offeredFmtp());
-            AudioPlayer player = new RtpAudioPlayer(media, callCodec, this.pcmDecoderFactory);
+            AudioPlayer player = new RtpAudioPlayer(media, media.codec(), this.pcmDecoderFactory);
 
             try {
                 this.announcementLoop.play(session, player, factory, sessionId, media);
             } finally {
-                callCodec.close();
+                media.codec().close();
             }
         });
 
@@ -273,15 +270,12 @@ public class CallAcceptor {
         // so RTP arrives within the endpoint's audio-delivery window (~1-2s).
         // Adding post-answer delays causes audio dropout on many SIP endpoints.
         Future<?> callFuture = this.managedExecutorService.submit(() -> {
-            // forCall() must run on the menu thread so that the confined Arena is owned
-            // by the thread that will also call encode() and close() — preventing WrongThreadException.
-            var callCodec = media.codecFactory().forCall(media.offeredFmtp());
-            AudioPlayer player = new RtpAudioPlayer(media, callCodec, this.pcmDecoderFactory);
+            AudioPlayer player = new RtpAudioPlayer(media, media.codec(), this.pcmDecoderFactory);
 
             try {
                 this.menuRunner.run(session, player, menu, sessionId, media);
             } finally {
-                callCodec.close();
+                media.codec().close();
             }
         });
         Future<?> receiverFuture = this.dtmfDispatcher.startReceiver(media, sessionId);
@@ -306,7 +300,7 @@ public class CallAcceptor {
                 "{0}200 OK — {1}, codec [{2}], remote RTP [{3}]",
                 SipCallHeaders.callPrefix(sessionId),
                 description,
-                media.codecFactory().metadata().sdpName(),
+                media.codec().metadata().sdpName(),
                 media.remoteRtp());
         SipServletResponse response = req.createResponse(SipServletResponse.SC_OK);
         response.setContent(media.sdpAnswer().getBytes(StandardCharsets.UTF_8), "application/sdp");

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
@@ -221,14 +221,16 @@ public class CallAcceptor {
         LinkedHashMap<Integer, LanguageFactory> singleMenu = new LinkedHashMap<>();
         singleMenu.put(1, factory);
 
-        // CRITICAL: Do NOT add a sleep/delay here.
-        // The 1-second ringing delay already happened in the INVITE handler thread (line 168)
-        // before 200 OK was sent. Audio playback must begin immediately after 200 OK
-        // so RTP arrives within the endpoint's audio-delivery window (~1-2s).
-        // Adding post-answer delays causes audio dropout on many SIP endpoints.
         Future<?> callFuture = this.managedExecutorService.submit(() -> {
             try (var codec = media.codecFactory().forCall()) {
                 AudioPlayer player = new RtpAudioPlayer(media, codec, this.pcmDecoderFactory);
+
+                LOGGER.log(
+                        System.Logger.Level.DEBUG,
+                        "{0}Sending 500ms silence to establish media path",
+                        SipCallHeaders.callPrefix(sessionId));
+                player.playSilence(java.time.Duration.ofMillis(500));
+
                 this.announcementLoop.play(session, player, factory, sessionId, media);
             } catch (Exception exception) {
                 LOGGER.log(
@@ -276,6 +278,13 @@ public class CallAcceptor {
         Future<?> callFuture = this.managedExecutorService.submit(() -> {
             try (var codec = media.codecFactory().forCall()) {
                 AudioPlayer player = new RtpAudioPlayer(media, codec, this.pcmDecoderFactory);
+
+                LOGGER.log(
+                        System.Logger.Level.DEBUG,
+                        "{0}Sending 500ms silence to establish media path",
+                        SipCallHeaders.callPrefix(sessionId));
+                player.playSilence(java.time.Duration.ofMillis(500));
+
                 this.menuRunner.run(session, player, menu, sessionId, media);
             } catch (Exception exception) {
                 LOGGER.log(

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
@@ -227,9 +227,8 @@ public class CallAcceptor {
         // so RTP arrives within the endpoint's audio-delivery window (~1-2s).
         // Adding post-answer delays causes audio dropout on many SIP endpoints.
         Future<?> callFuture = this.managedExecutorService.submit(() -> {
-            AudioPlayer player = new RtpAudioPlayer(media, media.codec(), this.pcmDecoderFactory);
-
-            try {
+            try (var codec = media.codecFactory().forCall("")) {
+                AudioPlayer player = new RtpAudioPlayer(media, codec, this.pcmDecoderFactory);
                 this.announcementLoop.play(session, player, factory, sessionId, media);
             } catch (Exception exception) {
                 LOGGER.log(
@@ -275,9 +274,8 @@ public class CallAcceptor {
         // so RTP arrives within the endpoint's audio-delivery window (~1-2s).
         // Adding post-answer delays causes audio dropout on many SIP endpoints.
         Future<?> callFuture = this.managedExecutorService.submit(() -> {
-            AudioPlayer player = new RtpAudioPlayer(media, media.codec(), this.pcmDecoderFactory);
-
-            try {
+            try (var codec = media.codecFactory().forCall("")) {
+                AudioPlayer player = new RtpAudioPlayer(media, codec, this.pcmDecoderFactory);
                 this.menuRunner.run(session, player, menu, sessionId, media);
             } catch (Exception exception) {
                 LOGGER.log(
@@ -310,7 +308,7 @@ public class CallAcceptor {
                 "{0}200 OK — {1}, codec [{2}], remote RTP [{3}]",
                 SipCallHeaders.callPrefix(sessionId),
                 description,
-                media.codec().metadata().sdpName(),
+                media.codecFactory().metadata().sdpName(),
                 media.remoteRtp());
         SipServletResponse response = req.createResponse(SipServletResponse.SC_OK);
         response.setContent(media.sdpAnswer().getBytes(StandardCharsets.UTF_8), "application/sdp");

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
@@ -231,8 +231,13 @@ public class CallAcceptor {
 
             try {
                 this.announcementLoop.play(session, player, factory, sessionId, media);
-            } finally {
-                media.codec().close();
+            } catch (Exception exception) {
+                LOGGER.log(
+                        System.Logger.Level.WARNING,
+                        "{0}Announcement playback failed: {1}",
+                        SipCallHeaders.callPrefix(sessionId),
+                        exception.getMessage(),
+                        exception);
             }
         });
 
@@ -274,8 +279,13 @@ public class CallAcceptor {
 
             try {
                 this.menuRunner.run(session, player, menu, sessionId, media);
-            } finally {
-                media.codec().close();
+            } catch (Exception exception) {
+                LOGGER.log(
+                        System.Logger.Level.WARNING,
+                        "{0}Menu playback failed: {1}",
+                        SipCallHeaders.callPrefix(sessionId),
+                        exception.getMessage(),
+                        exception);
             }
         });
         Future<?> receiverFuture = this.dtmfDispatcher.startReceiver(media, sessionId);

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallAcceptor.java
@@ -227,7 +227,7 @@ public class CallAcceptor {
         // so RTP arrives within the endpoint's audio-delivery window (~1-2s).
         // Adding post-answer delays causes audio dropout on many SIP endpoints.
         Future<?> callFuture = this.managedExecutorService.submit(() -> {
-            try (var codec = media.codecFactory().forCall("")) {
+            try (var codec = media.codecFactory().forCall()) {
                 AudioPlayer player = new RtpAudioPlayer(media, codec, this.pcmDecoderFactory);
                 this.announcementLoop.play(session, player, factory, sessionId, media);
             } catch (Exception exception) {
@@ -274,7 +274,7 @@ public class CallAcceptor {
         // so RTP arrives within the endpoint's audio-delivery window (~1-2s).
         // Adding post-answer delays causes audio dropout on many SIP endpoints.
         Future<?> callFuture = this.managedExecutorService.submit(() -> {
-            try (var codec = media.codecFactory().forCall("")) {
+            try (var codec = media.codecFactory().forCall()) {
                 AudioPlayer player = new RtpAudioPlayer(media, codec, this.pcmDecoderFactory);
                 this.menuRunner.run(session, player, menu, sessionId, media);
             } catch (Exception exception) {

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
@@ -129,9 +129,8 @@ public class CallSessionManager {
 
         callState.callFuture().cancel(true);
         callState.receiverFuture().cancel(true);
-        String codecName = callState.media().codec().metadata().sdpName();
+        String codecName = callState.media().codecFactory().metadata().sdpName();
         closeSocket(callState.media());
-        callState.media().close();
         Duration callDuration = Duration.between(callState.startTime(), Instant.now());
         LOGGER.log(
                 System.Logger.Level.INFO,

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
@@ -129,7 +129,7 @@ public class CallSessionManager {
 
         callState.callFuture().cancel(true);
         callState.receiverFuture().cancel(true);
-        String codecName = callState.media().codecFactory().metadata().sdpName();
+        String codecName = callState.media().codec().metadata().sdpName();
         closeSocket(callState.media());
         Duration callDuration = Duration.between(callState.startTime(), Instant.now());
         LOGGER.log(

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/CallSessionManager.java
@@ -131,6 +131,7 @@ public class CallSessionManager {
         callState.receiverFuture().cancel(true);
         String codecName = callState.media().codec().metadata().sdpName();
         closeSocket(callState.media());
+        callState.media().close();
         Duration callDuration = Duration.between(callState.startTime(), Instant.now());
         LOGGER.log(
                 System.Logger.Level.INFO,

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
@@ -21,9 +21,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Holds the negotiated media parameters for one call leg.
  *
  * <p>Created by {@link SdpNegotiator} from the SDP offer in the incoming INVITE.
- * The codec instance is created separately by the caller (typically on the executor thread)
- * and passed to CallMedia for use during RTP encoding.
- * The caller is responsible for closing the codec when the call ends.
+ * The codec instance is created during negotiation and owned by CallMedia.
+ * The caller must call {@link #close()} when the call ends to release the codec.
  *
  * <p>{@link #held} is an {@link AtomicBoolean} embedded in this record.
  * The record keeps its identity (the reference is final) while the hold state is
@@ -38,8 +37,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *                                  {@code c=} and {@code m=audio} lines
  * @param sdpAnswer                 the fully formatted SDP answer body to include in the 200 OK
  *                                  response
- * @param codec                     the negotiated RTP codec (already created, ready to encode);
- *                                  must be closed by the caller when the call ends
+ * @param codec                     the negotiated RTP codec (NegotiatedRtpCodec wrapping actual codec);
+ *                                  closed when {@link #close()} is called at end of call
  * @param telephoneEventPayloadType the dynamic RTP payload type negotiated for RFC 4733
  *                                  telephone-event, or {@code -1} if the remote side did not
  *                                  offer telephone-event in its SDP
@@ -52,7 +51,8 @@ public record CallMedia(
         String sdpAnswer,
         RtpCodec codec,
         int telephoneEventPayloadType,
-        AtomicBoolean held) {
+        AtomicBoolean held)
+        implements AutoCloseable {
 
     /**
      * Pauses RTP transmission.
@@ -75,5 +75,14 @@ public record CallMedia(
      */
     public boolean isHeld() {
         return this.held.get();
+    }
+
+    /**
+     * Closes the negotiated codec to release native resources and FFM arenas.
+     * Called when the call ends.
+     */
+    @Override
+    public void close() {
+        this.codec.close();
     }
 }

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
@@ -12,7 +12,7 @@
  */
 package de.bmarwell.proximo.pitido.war.media;
 
-import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
+import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecFactory;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -21,8 +21,10 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Holds the negotiated media parameters for one call leg.
  *
  * <p>Created by {@link SdpNegotiator} from the SDP offer in the incoming INVITE.
- * The codec instance is created during negotiation and owned by CallMedia.
- * The caller must call {@link #close()} when the call ends to release the codec.
+ * The negotiated codec factory and parameters are stored here.
+ * The actual RTP codec instance is created lazily on the executor thread by
+ * {@link RtpAudioPlayer} via the codec factory, so that confined FFM arenas
+ * are created on the correct thread.
  *
  * <p>{@link #held} is an {@link AtomicBoolean} embedded in this record.
  * The record keeps its identity (the reference is final) while the hold state is
@@ -37,8 +39,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *                                  {@code c=} and {@code m=audio} lines
  * @param sdpAnswer                 the fully formatted SDP answer body to include in the 200 OK
  *                                  response
- * @param codec                     the negotiated RTP codec (NegotiatedRtpCodec wrapping actual codec);
- *                                  closed when {@link #close()} is called at end of call
+ * @param codecFactory              the negotiated RTP codec factory (NegotiatedRtpCodecFactory)
+ *                                  carrying negotiated PT and offered fmtp; used to create
+ *                                  per-call codec on executor thread
  * @param telephoneEventPayloadType the dynamic RTP payload type negotiated for RFC 4733
  *                                  telephone-event, or {@code -1} if the remote side did not
  *                                  offer telephone-event in its SDP
@@ -49,10 +52,9 @@ public record CallMedia(
         DatagramSocket localSocket,
         InetSocketAddress remoteRtp,
         String sdpAnswer,
-        RtpCodec codec,
+        RtpCodecFactory codecFactory,
         int telephoneEventPayloadType,
-        AtomicBoolean held)
-        implements AutoCloseable {
+        AtomicBoolean held) {
 
     /**
      * Pauses RTP transmission.
@@ -75,14 +77,5 @@ public record CallMedia(
      */
     public boolean isHeld() {
         return this.held.get();
-    }
-
-    /**
-     * Closes the negotiated codec to release native resources and FFM arenas.
-     * Called when the call ends.
-     */
-    @Override
-    public void close() {
-        this.codec.close();
     }
 }

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
@@ -12,7 +12,6 @@
  */
 package de.bmarwell.proximo.pitido.war.media;
 
-import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecFactory;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -39,9 +38,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *                                  {@code c=} and {@code m=audio} lines
  * @param sdpAnswer                 the fully formatted SDP answer body to include in the 200 OK
  *                                  response
- * @param codecFactory              the negotiated RTP codec factory (NegotiatedRtpCodecFactory)
- *                                  carrying negotiated PT and offered fmtp; used to create
- *                                  per-call codec on executor thread
+ * @param codecFactory              the negotiated codec factory carrying negotiated PT and offered
+ *                                  fmtp; used to create per-call codec on executor thread
  * @param telephoneEventPayloadType the dynamic RTP payload type negotiated for RFC 4733
  *                                  telephone-event, or {@code -1} if the remote side did not
  *                                  offer telephone-event in its SDP
@@ -52,7 +50,7 @@ public record CallMedia(
         DatagramSocket localSocket,
         InetSocketAddress remoteRtp,
         String sdpAnswer,
-        RtpCodecFactory codecFactory,
+        NegotiatedRtpCodecFactory codecFactory,
         int telephoneEventPayloadType,
         AtomicBoolean held) {
 

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
@@ -12,7 +12,7 @@
  */
 package de.bmarwell.proximo.pitido.war.media;
 
-import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecFactory;
+import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -21,7 +21,9 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * Holds the negotiated media parameters for one call leg.
  *
  * <p>Created by {@link SdpNegotiator} from the SDP offer in the incoming INVITE.
- * The caller is responsible for closing {@link #localSocket()} when the call ends.
+ * The codec instance is created separately by the caller (typically on the executor thread)
+ * and passed to CallMedia for use during RTP encoding.
+ * The caller is responsible for closing the codec when the call ends.
  *
  * <p>{@link #held} is an {@link AtomicBoolean} embedded in this record.
  * The record keeps its identity (the reference is final) while the hold state is
@@ -36,8 +38,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  *                                  {@code c=} and {@code m=audio} lines
  * @param sdpAnswer                 the fully formatted SDP answer body to include in the 200 OK
  *                                  response
- * @param codec                     the negotiated RTP codec; determines payload type, encoding,
- *                                  and clock rate
+ * @param codec                     the negotiated RTP codec (already created, ready to encode);
+ *                                  must be closed by the caller when the call ends
  * @param telephoneEventPayloadType the dynamic RTP payload type negotiated for RFC 4733
  *                                  telephone-event, or {@code -1} if the remote side did not
  *                                  offer telephone-event in its SDP
@@ -48,8 +50,7 @@ public record CallMedia(
         DatagramSocket localSocket,
         InetSocketAddress remoteRtp,
         String sdpAnswer,
-        RtpCodecFactory codecFactory,
-        String offeredFmtp,
+        RtpCodec codec,
         int telephoneEventPayloadType,
         AtomicBoolean held) {
 

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/NegotiatedRtpCodec.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/NegotiatedRtpCodec.java
@@ -12,54 +12,36 @@
  */
 package de.bmarwell.proximo.pitido.war.media;
 
-import de.bmarwell.proximo.pitido.codecs.sip.AmrWbRtpCodecFactory;
 import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
-import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecFactory;
 import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecMetadata;
+import java.io.IOException;
 
 /**
- * Wraps a {@link RtpCodecFactory} and overrides {@link #payloadType()} to return the payload type
+ * Wraps an {@link RtpCodec} and overrides {@link #payloadType()} to return the payload type
  * actually negotiated with the caller rather than the codec's static default.
  *
  * <p>VoLTE callers (e.g. Deutsche Telekom) assign dynamic payload types (96–127) per-call via
  * {@code a=rtpmap} lines.
- * The underlying codec (e.g. {@link AmrWbRtpCodecFactory}) carries a
- * conventional default PT for identification purposes only.
+ * The underlying codec carries its conventional default PT for identification purposes only.
  * This wrapper carries the actual PT assigned by the caller so that outgoing RTP packet headers
  * and the SDP answer use the same PT value the caller expects.
  *
  * <h2>Lifecycle</h2>
  *
- * <p>{@link de.bmarwell.proximo.pitido.war.media.SdpNegotiator#negotiate} returns an instance
- * whose {@code delegate} is the CDI bean descriptor — no confined arena is allocated yet.
- * The announcement or menu-runner lambda calls {@link #forCall(String)} with the {@code offeredFmtp},
- * on the executor thread that will also call {@link #encode} and {@link #close}.
- * This guarantees that the {@link java.lang.foreign.Arena#ofConfined() confined arena} created by
+ * <p>Created by {@link CallMedia#getOrCreateCodec()} after the codec instance is created via
+ * {@code codecFactory.forCall(offeredFmtp)} on the executor thread.
+ * This ensures that the {@link java.lang.foreign.Arena#ofConfined() confined arena} created by
  * native codecs is owned by the thread that uses and closes it, preventing
  * {@link java.lang.WrongThreadException}.
  *
- * <p>All methods delegate transparently to the wrapped codec factory instance.
- * The {@link #metadata()} method returns a wrapped metadata that overrides {@code payloadType()}
- * to return the negotiated value.
+ * <p>All codec methods delegate transparently to the wrapped codec instance.
  *
- * @param delegate               the RtpCodecFactory CDI bean
- * @param negotiatedPayloadType  the payload type assigned by the caller in the SDP offer
- * @param offeredFmtp            the raw {@code a=fmtp} parameter string from the caller's SDP offer
- *                               for this payload type; empty string if no {@code a=fmtp} line was
- *                               present in the offer
+ * @param delegate                the RtpCodec instance
+ * @param negotiatedPayloadType   the payload type assigned by the caller in the SDP offer
+ * @param offeredFmtp             the raw {@code a=fmtp} parameter string from the caller's SDP offer;
+ *                                empty string if no {@code a=fmtp} line was present
  */
-record NegotiatedRtpCodec(RtpCodecFactory delegate, int negotiatedPayloadType, String offeredFmtp)
-        implements RtpCodecFactory {
-
-    @Override
-    public boolean isAvailable() {
-        return this.delegate.isAvailable();
-    }
-
-    @Override
-    public int preference() {
-        return this.delegate.preference();
-    }
+record NegotiatedRtpCodec(RtpCodec delegate, int negotiatedPayloadType, String offeredFmtp) implements RtpCodec {
 
     @Override
     public RtpCodecMetadata metadata() {
@@ -67,18 +49,23 @@ record NegotiatedRtpCodec(RtpCodecFactory delegate, int negotiatedPayloadType, S
     }
 
     @Override
-    public RtpCodec forCall(String offeredFmtp) {
-        return this.delegate.forCall(this.offeredFmtp);
-    }
-
-    @Override
-    public boolean matchesFmtp(String offeredFmtp) {
-        return this.delegate.matchesFmtp(offeredFmtp);
+    public byte[] encode(short[] pcmSamples) throws IOException {
+        return this.delegate.encode(pcmSamples);
     }
 
     @Override
     public String fmtpAnswer(String offeredFmtp) {
         return this.delegate.fmtpAnswer(offeredFmtp);
+    }
+
+    @Override
+    public String fmtpParams() {
+        return this.delegate.fmtpParams();
+    }
+
+    @Override
+    public void close() {
+        this.delegate.close();
     }
 
     /**

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/NegotiatedRtpCodecFactory.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/NegotiatedRtpCodecFactory.java
@@ -17,75 +17,62 @@ import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecFactory;
 import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecMetadata;
 
 /**
- * Wraps an {@link RtpCodecFactory} and carries the negotiated payload type and offered fmtp parameters
- * from SDP negotiation.
+ * Encapsulates the negotiated codec state: payload type and offered fmtp parameters from SDP negotiation.
  *
- * <p>Created by {@link SdpNegotiator} during SDP offer processing and passed to the executor thread.
- * The executor thread calls {@link #forCall(String)} to create the actual {@link RtpCodec} instance
- * with confined FFM arenas on the executor thread.
+ * <p>Replaces the need to pass both codec factory and metadata separately across thread boundaries.
+ * Created by {@link SdpNegotiator} during SDP offer processing and passed to the executor thread.
  *
- * <p>The {@code fmtpAnswer()} method uses the stored {@code offeredFmtp} to generate the correct
- * SDP answer parameters, enabling SDP answer building on the servlet thread before the executor thread
- * receives the factory.
+ * <p>Two phases of use:
+ * <ul>
+ *   <li><strong>Servlet thread (SDP negotiation):</strong> Call {@code fmtpAnswer()} to generate
+ *       correct fmtp parameters for the SDP answer, without creating a codec instance.
+ *   <li><strong>Executor thread (RTP encoding):</strong> Call {@code forCall()} to create the actual
+ *       {@link RtpCodec} instance with confined FFM arenas on the thread where it will be used.
+ * </ul>
  *
- * <h2>Lifecycle</h2>
+ * <p>Key invariant: both phases can complete successfully using only the wrapped factory and
+ * negotiated state, without needing a per-call codec instance until the executor thread.
  *
- * <p>Servlet thread:
- * <ol>
- *   <li>Negotiate codec selection from SDP offer
- *   <li>Create {@code NegotiatedRtpCodecFactory} with negotiated PT and offered fmtp
- *   <li>Call {@code fmtpAnswer()} for SDP answer generation
- *   <li>Pass to executor thread via {@link CallMedia}
- * </ol>
- *
- * <p>Executor thread:
- * <ol>
- *   <li>Call {@code forCall("")} (empty string; fmtp already captured)
- *   <li>Wrap result in try-with-resources or equivalent
- *   <li>Use codec for RTP encoding
- *   <li>Close codec when done
- * </ol>
- *
- * @param delegate              the underlying codec factory
- * @param negotiatedPayloadType the payload type assigned by the caller in the SDP offer
+ * @param delegate              the underlying codec factory (stateless)
+ * @param negotiatedPayloadType the RTP payload type assigned by the caller in the SDP offer
  * @param offeredFmtp           the raw {@code a=fmtp} parameter string from the caller's SDP offer;
  *                              empty string if no {@code a=fmtp} line was present
  */
-public record NegotiatedRtpCodecFactory(RtpCodecFactory delegate, int negotiatedPayloadType, String offeredFmtp)
-        implements RtpCodecFactory {
+public record NegotiatedRtpCodecFactory(RtpCodecFactory delegate, int negotiatedPayloadType, String offeredFmtp) {
 
-    @Override
-    public boolean isAvailable() {
-        return this.delegate.isAvailable();
-    }
-
-    @Override
-    public int preference() {
-        return this.delegate.preference();
-    }
-
-    @Override
-    public RtpCodecMetadata metadata() {
-        return new WrappedMetadata(this.delegate.metadata(), this.negotiatedPayloadType);
-    }
-
-    @Override
-    public boolean matchesFmtp(String offeredFmtp) {
-        return this.delegate.matchesFmtp(offeredFmtp);
-    }
-
-    @Override
-    public RtpCodec forCall(String offeredFmtp) {
-        // Use the stored offeredFmtp from negotiation, not the parameter
-        // (parameter is ignored; method signature matches RtpCodecFactory contract).
+    /**
+     * Creates an {@link RtpCodec} instance for this call, with negotiated payload type and fmtp.
+     *
+     * <p>Must be called on the thread where the codec will be used (typically executor thread).
+     * The codec is wrapped to override {@code payloadType()} with the negotiated value.
+     *
+     * @return a codec instance configured for RTP encoding on this call
+     */
+    public RtpCodec forCall() {
         RtpCodec actualCodec = this.delegate.forCall(this.offeredFmtp);
         return new NegotiatedRtpCodec(actualCodec, this.negotiatedPayloadType, this.offeredFmtp);
     }
 
-    @Override
-    public String fmtpAnswer(String offeredFmtp) {
-        // Use the stored offeredFmtp from negotiation.
+    /**
+     * Generates the fmtp parameters for the SDP answer using stored negotiated state.
+     *
+     * <p>Delegates to the underlying factory's {@code fmtpAnswer()}, which uses only the
+     * {@code offeredFmtp} to generate an answer—no codec instance needed.
+     * Safe to call on any thread during SDP negotiation.
+     *
+     * @return the fmtp parameter string for the SDP answer
+     */
+    public String fmtpAnswer() {
         return this.delegate.fmtpAnswer(this.offeredFmtp);
+    }
+
+    /**
+     * Returns codec metadata with {@code payloadType()} overridden to the negotiated value.
+     *
+     * @return metadata with negotiated payload type
+     */
+    public RtpCodecMetadata metadata() {
+        return new WrappedMetadata(this.delegate.metadata(), this.negotiatedPayloadType);
     }
 
     /**

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/NegotiatedRtpCodecFactory.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/NegotiatedRtpCodecFactory.java
@@ -1,0 +1,133 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.war.media;
+
+import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
+import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecFactory;
+import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecMetadata;
+
+/**
+ * Wraps an {@link RtpCodecFactory} and carries the negotiated payload type and offered fmtp parameters
+ * from SDP negotiation.
+ *
+ * <p>Created by {@link SdpNegotiator} during SDP offer processing and passed to the executor thread.
+ * The executor thread calls {@link #forCall(String)} to create the actual {@link RtpCodec} instance
+ * with confined FFM arenas on the executor thread.
+ *
+ * <p>The {@code fmtpAnswer()} method uses the stored {@code offeredFmtp} to generate the correct
+ * SDP answer parameters, enabling SDP answer building on the servlet thread before the executor thread
+ * receives the factory.
+ *
+ * <h2>Lifecycle</h2>
+ *
+ * <p>Servlet thread:
+ * <ol>
+ *   <li>Negotiate codec selection from SDP offer
+ *   <li>Create {@code NegotiatedRtpCodecFactory} with negotiated PT and offered fmtp
+ *   <li>Call {@code fmtpAnswer()} for SDP answer generation
+ *   <li>Pass to executor thread via {@link CallMedia}
+ * </ol>
+ *
+ * <p>Executor thread:
+ * <ol>
+ *   <li>Call {@code forCall("")} (empty string; fmtp already captured)
+ *   <li>Wrap result in try-with-resources or equivalent
+ *   <li>Use codec for RTP encoding
+ *   <li>Close codec when done
+ * </ol>
+ *
+ * @param delegate              the underlying codec factory
+ * @param negotiatedPayloadType the payload type assigned by the caller in the SDP offer
+ * @param offeredFmtp           the raw {@code a=fmtp} parameter string from the caller's SDP offer;
+ *                              empty string if no {@code a=fmtp} line was present
+ */
+public record NegotiatedRtpCodecFactory(RtpCodecFactory delegate, int negotiatedPayloadType, String offeredFmtp)
+        implements RtpCodecFactory {
+
+    @Override
+    public boolean isAvailable() {
+        return this.delegate.isAvailable();
+    }
+
+    @Override
+    public int preference() {
+        return this.delegate.preference();
+    }
+
+    @Override
+    public RtpCodecMetadata metadata() {
+        return new WrappedMetadata(this.delegate.metadata(), this.negotiatedPayloadType);
+    }
+
+    @Override
+    public boolean matchesFmtp(String offeredFmtp) {
+        return this.delegate.matchesFmtp(offeredFmtp);
+    }
+
+    @Override
+    public RtpCodec forCall(String offeredFmtp) {
+        // Use the stored offeredFmtp from negotiation, not the parameter
+        // (parameter is ignored; method signature matches RtpCodecFactory contract).
+        RtpCodec actualCodec = this.delegate.forCall(this.offeredFmtp);
+        return new NegotiatedRtpCodec(actualCodec, this.negotiatedPayloadType, this.offeredFmtp);
+    }
+
+    @Override
+    public String fmtpAnswer(String offeredFmtp) {
+        // Use the stored offeredFmtp from negotiation.
+        return this.delegate.fmtpAnswer(this.offeredFmtp);
+    }
+
+    /**
+     * Wraps delegate metadata and overrides {@code payloadType()} to return the negotiated value.
+     *
+     * <p>All other metadata methods delegate to the wrapped metadata unchanged.
+     */
+    private record WrappedMetadata(RtpCodecMetadata delegate, int negotiatedPayloadType) implements RtpCodecMetadata {
+
+        @Override
+        public int payloadType() {
+            return this.negotiatedPayloadType;
+        }
+
+        @Override
+        public int rtpClockRate() {
+            return this.delegate.rtpClockRate();
+        }
+
+        @Override
+        public int inputSampleRate() {
+            return this.delegate.inputSampleRate();
+        }
+
+        @Override
+        public int samplesPerFrame() {
+            return this.delegate.samplesPerFrame();
+        }
+
+        @Override
+        public int rtpTimestampIncrement() {
+            return this.delegate.rtpTimestampIncrement();
+        }
+
+        @Override
+        public String sdpName() {
+            return this.delegate.sdpName();
+        }
+
+        @Override
+        public int sdpChannelCount() {
+            return this.delegate.sdpChannelCount();
+        }
+    }
+}

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -290,7 +290,7 @@ public class SdpNegotiator {
         Map<Integer, String> rtpmap = parseRtpmap(sdpOffer);
         Map<Integer, String> fmtp = parseFmtp(sdpOffer);
 
-        record SelectionResult(RtpCodecFactory factory, int negotiatedPt, String offeredFmtp) {}
+        record SelectionResult(RtpCodecFactory codecFactory, int negotiatedPt, String offeredFmtp) {}
 
         Optional<SelectionResult> selected = this.availableCodecFactories.stream()
                 .filter(RtpCodecFactory::isAvailable)
@@ -312,13 +312,13 @@ public class SdpNegotiator {
         LOGGER.log(
                 System.Logger.Level.DEBUG,
                 "Codec selected: {0} (negotiated PT {1}) from offered payload types {2}",
-                result.factory.metadata().sdpName(),
+                result.codecFactory.metadata().sdpName(),
                 result.negotiatedPt,
                 offeredPts);
 
         // Wrap factory with negotiated PT and offered fmtp to enable fmtpAnswer during SDP building
         // and codec creation on executor thread.
-        return new NegotiatedRtpCodecFactory(result.factory, result.negotiatedPt, result.offeredFmtp);
+        return new NegotiatedRtpCodecFactory(result.codecFactory, result.negotiatedPt, result.offeredFmtp);
     }
 
     /**

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -446,7 +446,7 @@ public class SdpNegotiator {
 
         sdp.append("\r\n");
 
-        String fmtpParams = negotiatedCodecFactory.fmtpAnswer(negotiatedCodecFactory.offeredFmtp());
+        String fmtpParams = negotiatedCodecFactory.fmtpAnswer();
         LOGGER.log(
                 System.Logger.Level.TRACE,
                 "SDP answer fmtp: codec={0} PT={1} fmtpParams=''{2}''",

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -13,6 +13,7 @@
 package de.bmarwell.proximo.pitido.war.media;
 
 import de.bmarwell.proximo.pitido.codecs.sip.PcmaRtpCodecFactory;
+import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
 import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecFactory;
 import de.bmarwell.proximo.pitido.core.sip.LocalSipHostProvider;
 import java.io.IOException;
@@ -59,15 +60,6 @@ public class SdpNegotiator {
 
     private static final int PTIME_MS = 20;
 
-    /**
-     * Result of codec selection during SDP negotiation.
-     *
-     * @param codecFactory       the selected codec factory
-     * @param negotiatedPayloadType the payload type assigned by the caller
-     * @param offeredFmtp        the fmtp parameters from the offer, or empty string
-     */
-    record CodecSelection(RtpCodecFactory codecFactory, int negotiatedPayloadType, String offeredFmtp) {}
-
     @Inject
     LocalSipHostProvider localSipHostProvider;
 
@@ -101,7 +93,7 @@ public class SdpNegotiator {
         String remoteIp = parseConnectionIp(sdpOffer);
         int remotePort = parseAudioPort(sdpOffer);
         int telephoneEventPt = parseTelephoneEventPayloadType(sdpOffer);
-        CodecSelection codecSel = selectCodec(sdpOffer);
+        NegotiatedRtpCodec negotiatedCodec = selectCodec(sdpOffer);
 
         DatagramSocket localSocket = new DatagramSocket(0);
         int localPort = localSocket.getLocalPort();
@@ -115,16 +107,11 @@ public class SdpNegotiator {
                 localPort,
                 remoteIp,
                 remotePort,
-                codecSel.codecFactory.metadata().sdpName(),
+                negotiatedCodec.metadata().sdpName(),
                 telephoneEventPt);
 
-        String sdpAnswer = buildSdpAnswer(localIp, localPort, codecSel, telephoneEventPt);
+        String sdpAnswer = buildSdpAnswer(localIp, localPort, negotiatedCodec, telephoneEventPt);
         InetSocketAddress remoteAddr = new InetSocketAddress(remoteIp, remotePort);
-
-        // Create the actual codec now (needed for fmtpAnswer during SDP building).
-        // Wrap it with negotiated PT for use during encoding.
-        var actualCodec = codecSel.codecFactory.forCall(codecSel.offeredFmtp);
-        var negotiatedCodec = new NegotiatedRtpCodec(actualCodec, codecSel.negotiatedPayloadType, codecSel.offeredFmtp);
 
         return new CallMedia(
                 localSocket, remoteAddr, sdpAnswer, negotiatedCodec, telephoneEventPt, new AtomicBoolean(false));
@@ -305,7 +292,7 @@ public class SdpNegotiator {
      *         actually negotiated with the caller; callers must call {@link RtpCodecFactory#forCall()}
      *         on the announcement thread before encoding
      */
-    private CodecSelection selectCodec(String sdpOffer) {
+    private NegotiatedRtpCodec selectCodec(String sdpOffer) {
         return selectCodec(this.availableCodecFactories.stream(), sdpOffer, () -> this.pcmaFallback.get());
     }
 
@@ -317,9 +304,9 @@ public class SdpNegotiator {
      * @param codecs      available codec descriptors, each an {@code @ApplicationScoped} CDI bean
      * @param sdpOffer    the full SDP offer string from the INVITE body
      * @param fallbackSupplier Supplier for PCMA codec factory as fallback
-     * @return a codec descriptor with factory, negotiated PT, and offered fmtp
+     * @return a NegotiatedRtpCodec wrapping the selected codec with negotiated PT and fmtp
      */
-    static CodecSelection selectCodec(
+    static NegotiatedRtpCodec selectCodec(
             Stream<RtpCodecFactory> codecs, String sdpOffer, Supplier<RtpCodecFactory> fallbackSupplier) {
         Set<Integer> offeredPts = parseOfferedPayloadTypes(sdpOffer, fallbackSupplier);
         Map<Integer, String> rtpmap = parseRtpmap(sdpOffer);
@@ -350,7 +337,9 @@ public class SdpNegotiator {
                 result.negotiatedPt,
                 offeredPts);
 
-        return new CodecSelection(result.factory, result.negotiatedPt, result.offeredFmtp);
+        // Create actual codec and wrap it immediately to enable fmtpAnswer during SDP building.
+        RtpCodec actualCodec = result.factory.forCall(result.offeredFmtp);
+        return new NegotiatedRtpCodec(actualCodec, result.negotiatedPt, result.offeredFmtp);
     }
 
     /**
@@ -422,9 +411,9 @@ public class SdpNegotiator {
         return Optional.empty();
     }
 
-    private static String buildSdpAnswer(String localIp, int localPort, CodecSelection codecSel, int telephoneEventPt) {
+    private static String buildSdpAnswer(
+            String localIp, int localPort, NegotiatedRtpCodec negotiatedCodec, int telephoneEventPt) {
         StringBuilder sdp = new StringBuilder();
-        RtpCodecFactory codecFactory = codecSel.codecFactory;
 
         sdp.append("v=0\r\n")
                 .append("o=proximo-pitido 0 0 IN IP4 ")
@@ -438,7 +427,7 @@ public class SdpNegotiator {
                 .append("m=audio ")
                 .append(localPort)
                 .append(" RTP/AVP ")
-                .append(codecSel.negotiatedPayloadType);
+                .append(negotiatedCodec.metadata().payloadType());
 
         if (telephoneEventPt >= 0) {
             sdp.append(" ").append(telephoneEventPt);
@@ -446,29 +435,29 @@ public class SdpNegotiator {
 
         sdp.append("\r\n")
                 .append("a=rtpmap:")
-                .append(codecSel.negotiatedPayloadType)
+                .append(negotiatedCodec.metadata().payloadType())
                 .append(" ")
-                .append(codecFactory.metadata().sdpName())
+                .append(negotiatedCodec.metadata().sdpName())
                 .append("/")
-                .append(codecFactory.metadata().rtpClockRate());
+                .append(negotiatedCodec.metadata().rtpClockRate());
 
-        if (codecFactory.metadata().sdpChannelCount() > 1) {
-            sdp.append("/").append(codecFactory.metadata().sdpChannelCount());
+        if (negotiatedCodec.metadata().sdpChannelCount() > 1) {
+            sdp.append("/").append(negotiatedCodec.metadata().sdpChannelCount());
         }
 
         sdp.append("\r\n");
 
-        String fmtpParams = codecFactory.fmtpAnswer(codecSel.offeredFmtp);
+        String fmtpParams = negotiatedCodec.fmtpAnswer(negotiatedCodec.offeredFmtp());
         LOGGER.log(
                 System.Logger.Level.TRACE,
                 "SDP answer fmtp: codec={0} PT={1} fmtpParams=''{2}''",
-                codecFactory.metadata().sdpName(),
-                codecSel.negotiatedPayloadType,
+                negotiatedCodec.metadata().sdpName(),
+                negotiatedCodec.metadata().payloadType(),
                 fmtpParams);
 
         if (!fmtpParams.isEmpty()) {
             sdp.append("a=fmtp:")
-                    .append(codecSel.negotiatedPayloadType)
+                    .append(negotiatedCodec.metadata().payloadType())
                     .append(" ")
                     .append(fmtpParams)
                     .append("\r\n");
@@ -485,7 +474,7 @@ public class SdpNegotiator {
         LOGGER.log(
                 System.Logger.Level.DEBUG,
                 "{0}SDP answer:{1}{2}",
-                callPrefix(codecFactory.metadata().sdpName()),
+                callPrefix(negotiatedCodec.metadata().sdpName()),
                 System.lineSeparator(),
                 answer);
 

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -13,7 +13,6 @@
 package de.bmarwell.proximo.pitido.war.media;
 
 import de.bmarwell.proximo.pitido.codecs.sip.PcmaRtpCodecFactory;
-import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
 import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecFactory;
 import de.bmarwell.proximo.pitido.core.sip.LocalSipHostProvider;
 import java.io.IOException;
@@ -93,7 +92,7 @@ public class SdpNegotiator {
         String remoteIp = parseConnectionIp(sdpOffer);
         int remotePort = parseAudioPort(sdpOffer);
         int telephoneEventPt = parseTelephoneEventPayloadType(sdpOffer);
-        NegotiatedRtpCodec negotiatedCodec = selectCodec(sdpOffer);
+        NegotiatedRtpCodecFactory negotiatedCodecFactory = selectCodec(sdpOffer);
 
         DatagramSocket localSocket = new DatagramSocket(0);
         int localPort = localSocket.getLocalPort();
@@ -107,14 +106,14 @@ public class SdpNegotiator {
                 localPort,
                 remoteIp,
                 remotePort,
-                negotiatedCodec.metadata().sdpName(),
+                negotiatedCodecFactory.metadata().sdpName(),
                 telephoneEventPt);
 
-        String sdpAnswer = buildSdpAnswer(localIp, localPort, negotiatedCodec, telephoneEventPt);
+        String sdpAnswer = buildSdpAnswer(localIp, localPort, negotiatedCodecFactory, telephoneEventPt);
         InetSocketAddress remoteAddr = new InetSocketAddress(remoteIp, remotePort);
 
         return new CallMedia(
-                localSocket, remoteAddr, sdpAnswer, negotiatedCodec, telephoneEventPt, new AtomicBoolean(false));
+                localSocket, remoteAddr, sdpAnswer, negotiatedCodecFactory, telephoneEventPt, new AtomicBoolean(false));
     }
 
     private static String readSdpBody(SipServletRequest req) throws IOException {
@@ -292,7 +291,7 @@ public class SdpNegotiator {
      *         actually negotiated with the caller; callers must call {@link RtpCodecFactory#forCall()}
      *         on the announcement thread before encoding
      */
-    private NegotiatedRtpCodec selectCodec(String sdpOffer) {
+    private NegotiatedRtpCodecFactory selectCodec(String sdpOffer) {
         return selectCodec(this.availableCodecFactories.stream(), sdpOffer, () -> this.pcmaFallback.get());
     }
 
@@ -304,9 +303,9 @@ public class SdpNegotiator {
      * @param codecs      available codec descriptors, each an {@code @ApplicationScoped} CDI bean
      * @param sdpOffer    the full SDP offer string from the INVITE body
      * @param fallbackSupplier Supplier for PCMA codec factory as fallback
-     * @return a NegotiatedRtpCodec wrapping the selected codec with negotiated PT and fmtp
+     * @return a NegotiatedRtpCodecFactory wrapping the selected factory with negotiated PT and fmtp
      */
-    static NegotiatedRtpCodec selectCodec(
+    static NegotiatedRtpCodecFactory selectCodec(
             Stream<RtpCodecFactory> codecs, String sdpOffer, Supplier<RtpCodecFactory> fallbackSupplier) {
         Set<Integer> offeredPts = parseOfferedPayloadTypes(sdpOffer, fallbackSupplier);
         Map<Integer, String> rtpmap = parseRtpmap(sdpOffer);
@@ -337,9 +336,9 @@ public class SdpNegotiator {
                 result.negotiatedPt,
                 offeredPts);
 
-        // Create actual codec and wrap it immediately to enable fmtpAnswer during SDP building.
-        RtpCodec actualCodec = result.factory.forCall(result.offeredFmtp);
-        return new NegotiatedRtpCodec(actualCodec, result.negotiatedPt, result.offeredFmtp);
+        // Wrap factory with negotiated PT and offered fmtp to enable fmtpAnswer during SDP building
+        // and codec creation on executor thread.
+        return new NegotiatedRtpCodecFactory(result.factory, result.negotiatedPt, result.offeredFmtp);
     }
 
     /**
@@ -412,7 +411,7 @@ public class SdpNegotiator {
     }
 
     private static String buildSdpAnswer(
-            String localIp, int localPort, NegotiatedRtpCodec negotiatedCodec, int telephoneEventPt) {
+            String localIp, int localPort, NegotiatedRtpCodecFactory negotiatedCodecFactory, int telephoneEventPt) {
         StringBuilder sdp = new StringBuilder();
 
         sdp.append("v=0\r\n")
@@ -427,7 +426,7 @@ public class SdpNegotiator {
                 .append("m=audio ")
                 .append(localPort)
                 .append(" RTP/AVP ")
-                .append(negotiatedCodec.metadata().payloadType());
+                .append(negotiatedCodecFactory.metadata().payloadType());
 
         if (telephoneEventPt >= 0) {
             sdp.append(" ").append(telephoneEventPt);
@@ -435,29 +434,29 @@ public class SdpNegotiator {
 
         sdp.append("\r\n")
                 .append("a=rtpmap:")
-                .append(negotiatedCodec.metadata().payloadType())
+                .append(negotiatedCodecFactory.metadata().payloadType())
                 .append(" ")
-                .append(negotiatedCodec.metadata().sdpName())
+                .append(negotiatedCodecFactory.metadata().sdpName())
                 .append("/")
-                .append(negotiatedCodec.metadata().rtpClockRate());
+                .append(negotiatedCodecFactory.metadata().rtpClockRate());
 
-        if (negotiatedCodec.metadata().sdpChannelCount() > 1) {
-            sdp.append("/").append(negotiatedCodec.metadata().sdpChannelCount());
+        if (negotiatedCodecFactory.metadata().sdpChannelCount() > 1) {
+            sdp.append("/").append(negotiatedCodecFactory.metadata().sdpChannelCount());
         }
 
         sdp.append("\r\n");
 
-        String fmtpParams = negotiatedCodec.fmtpAnswer(negotiatedCodec.offeredFmtp());
+        String fmtpParams = negotiatedCodecFactory.fmtpAnswer(negotiatedCodecFactory.offeredFmtp());
         LOGGER.log(
                 System.Logger.Level.TRACE,
                 "SDP answer fmtp: codec={0} PT={1} fmtpParams=''{2}''",
-                negotiatedCodec.metadata().sdpName(),
-                negotiatedCodec.metadata().payloadType(),
+                negotiatedCodecFactory.metadata().sdpName(),
+                negotiatedCodecFactory.metadata().payloadType(),
                 fmtpParams);
 
         if (!fmtpParams.isEmpty()) {
             sdp.append("a=fmtp:")
-                    .append(negotiatedCodec.metadata().payloadType())
+                    .append(negotiatedCodecFactory.metadata().payloadType())
                     .append(" ")
                     .append(fmtpParams)
                     .append("\r\n");
@@ -474,7 +473,7 @@ public class SdpNegotiator {
         LOGGER.log(
                 System.Logger.Level.DEBUG,
                 "{0}SDP answer:{1}{2}",
-                callPrefix(negotiatedCodec.metadata().sdpName()),
+                callPrefix(negotiatedCodecFactory.metadata().sdpName()),
                 System.lineSeparator(),
                 answer);
 

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -59,6 +59,15 @@ public class SdpNegotiator {
 
     private static final int PTIME_MS = 20;
 
+    /**
+     * Result of codec selection during SDP negotiation.
+     *
+     * @param codecFactory       the selected codec factory
+     * @param negotiatedPayloadType the payload type assigned by the caller
+     * @param offeredFmtp        the fmtp parameters from the offer, or empty string
+     */
+    record CodecSelection(RtpCodecFactory codecFactory, int negotiatedPayloadType, String offeredFmtp) {}
+
     @Inject
     LocalSipHostProvider localSipHostProvider;
 
@@ -73,10 +82,12 @@ public class SdpNegotiator {
      *
      * <p>Parses the SDP offer, allocates a UDP socket on an OS-assigned port, and builds
      * the SDP answer using the configured public host address.
+     * Creates the codec immediately to enable fmtpAnswer() for SDP negotiation,
+     * then wraps it in NegotiatedRtpCodec with the negotiated payload type.
      *
      * @param invite the incoming INVITE request; must contain a valid SDP offer body
      * @return a {@link CallMedia} containing the allocated socket, remote RTP address,
-     *         and the SDP answer text
+     *         SDP answer text, and the negotiated codec
      * @throws IOException if the SDP body cannot be read, the offer is malformed, or
      *                     the local UDP socket cannot be created
      */
@@ -90,7 +101,7 @@ public class SdpNegotiator {
         String remoteIp = parseConnectionIp(sdpOffer);
         int remotePort = parseAudioPort(sdpOffer);
         int telephoneEventPt = parseTelephoneEventPayloadType(sdpOffer);
-        RtpCodecFactory codec = selectCodec(sdpOffer);
+        CodecSelection codecSel = selectCodec(sdpOffer);
 
         DatagramSocket localSocket = new DatagramSocket(0);
         int localPort = localSocket.getLocalPort();
@@ -104,16 +115,19 @@ public class SdpNegotiator {
                 localPort,
                 remoteIp,
                 remotePort,
-                codec.getClass().getSimpleName(),
+                codecSel.codecFactory.metadata().sdpName(),
                 telephoneEventPt);
 
-        String sdpAnswer = buildSdpAnswer(localIp, localPort, codec, telephoneEventPt);
+        String sdpAnswer = buildSdpAnswer(localIp, localPort, codecSel, telephoneEventPt);
         InetSocketAddress remoteAddr = new InetSocketAddress(remoteIp, remotePort);
 
-        String offeredFmtp = (codec instanceof NegotiatedRtpCodec negotiated) ? negotiated.offeredFmtp() : "";
+        // Create the actual codec now (needed for fmtpAnswer during SDP building).
+        // Wrap it with negotiated PT for use during encoding.
+        var actualCodec = codecSel.codecFactory.forCall(codecSel.offeredFmtp);
+        var negotiatedCodec = new NegotiatedRtpCodec(actualCodec, codecSel.negotiatedPayloadType, codecSel.offeredFmtp);
 
         return new CallMedia(
-                localSocket, remoteAddr, sdpAnswer, codec, offeredFmtp, telephoneEventPt, new AtomicBoolean(false));
+                localSocket, remoteAddr, sdpAnswer, negotiatedCodec, telephoneEventPt, new AtomicBoolean(false));
     }
 
     private static String readSdpBody(SipServletRequest req) throws IOException {
@@ -291,7 +305,7 @@ public class SdpNegotiator {
      *         actually negotiated with the caller; callers must call {@link RtpCodecFactory#forCall()}
      *         on the announcement thread before encoding
      */
-    private RtpCodecFactory selectCodec(String sdpOffer) {
+    private CodecSelection selectCodec(String sdpOffer) {
         return selectCodec(this.availableCodecFactories.stream(), sdpOffer, () -> this.pcmaFallback.get());
     }
 
@@ -303,19 +317,20 @@ public class SdpNegotiator {
      * @param codecs      available codec descriptors, each an {@code @ApplicationScoped} CDI bean
      * @param sdpOffer    the full SDP offer string from the INVITE body
      * @param fallbackSupplier Supplier for PCMA codec factory as fallback
-     * @return a {@link NegotiatedRtpCodec} wrapping the selected codec descriptor with the
-     *         negotiated payload type; call {@link RtpCodecFactory#forCall(String)} on the announcement thread
+     * @return a codec descriptor with factory, negotiated PT, and offered fmtp
      */
-    static RtpCodecFactory selectCodec(
+    static CodecSelection selectCodec(
             Stream<RtpCodecFactory> codecs, String sdpOffer, Supplier<RtpCodecFactory> fallbackSupplier) {
         Set<Integer> offeredPts = parseOfferedPayloadTypes(sdpOffer, fallbackSupplier);
         Map<Integer, String> rtpmap = parseRtpmap(sdpOffer);
         Map<Integer, String> fmtp = parseFmtp(sdpOffer);
 
-        Optional<NegotiatedRtpCodec> selected = codecs.filter(RtpCodecFactory::isAvailable)
+        record SelectionResult(RtpCodecFactory factory, int negotiatedPt, String offeredFmtp) {}
+
+        Optional<SelectionResult> selected = codecs.filter(RtpCodecFactory::isAvailable)
                 .sorted(Comparator.comparingInt(RtpCodecFactory::preference))
                 .flatMap(codec -> negotiatedPt(codec, offeredPts, rtpmap, fmtp)
-                        .map(pt -> new NegotiatedRtpCodec(codec, pt, fmtp.getOrDefault(pt, "")))
+                        .map(pt -> new SelectionResult(codec, pt, fmtp.getOrDefault(pt, "")))
                         .stream())
                 .findFirst();
 
@@ -323,17 +338,19 @@ public class SdpNegotiator {
             LOGGER.log(System.Logger.Level.DEBUG, "No matching codec found in SDP offer; falling back to PCMA (PT 8)");
         }
 
-        NegotiatedRtpCodec result = selected.orElseGet(() -> new NegotiatedRtpCodec(
-                fallbackSupplier.get(), fallbackSupplier.get().metadata().payloadType(), ""));
+        SelectionResult result = selected.orElseGet(() -> {
+            RtpCodecFactory fallback = fallbackSupplier.get();
+            return new SelectionResult(fallback, fallback.metadata().payloadType(), "");
+        });
 
         LOGGER.log(
                 System.Logger.Level.DEBUG,
                 "Codec selected: {0} (negotiated PT {1}) from offered payload types {2}",
-                result.metadata().sdpName(),
-                result.metadata().payloadType(),
+                result.factory.metadata().sdpName(),
+                result.negotiatedPt,
                 offeredPts);
 
-        return result;
+        return new CodecSelection(result.factory, result.negotiatedPt, result.offeredFmtp);
     }
 
     /**
@@ -405,8 +422,10 @@ public class SdpNegotiator {
         return Optional.empty();
     }
 
-    private static String buildSdpAnswer(String localIp, int localPort, RtpCodecFactory codec, int telephoneEventPt) {
+    private static String buildSdpAnswer(String localIp, int localPort, CodecSelection codecSel, int telephoneEventPt) {
         StringBuilder sdp = new StringBuilder();
+        RtpCodecFactory codecFactory = codecSel.codecFactory;
+
         sdp.append("v=0\r\n")
                 .append("o=proximo-pitido 0 0 IN IP4 ")
                 .append(localIp)
@@ -419,7 +438,7 @@ public class SdpNegotiator {
                 .append("m=audio ")
                 .append(localPort)
                 .append(" RTP/AVP ")
-                .append(codec.metadata().payloadType());
+                .append(codecSel.negotiatedPayloadType);
 
         if (telephoneEventPt >= 0) {
             sdp.append(" ").append(telephoneEventPt);
@@ -427,30 +446,29 @@ public class SdpNegotiator {
 
         sdp.append("\r\n")
                 .append("a=rtpmap:")
-                .append(codec.metadata().payloadType())
+                .append(codecSel.negotiatedPayloadType)
                 .append(" ")
-                .append(codec.metadata().sdpName())
+                .append(codecFactory.metadata().sdpName())
                 .append("/")
-                .append(codec.metadata().rtpClockRate());
+                .append(codecFactory.metadata().rtpClockRate());
 
-        if (codec.metadata().sdpChannelCount() > 1) {
-            sdp.append("/").append(codec.metadata().sdpChannelCount());
+        if (codecFactory.metadata().sdpChannelCount() > 1) {
+            sdp.append("/").append(codecFactory.metadata().sdpChannelCount());
         }
 
         sdp.append("\r\n");
 
-        String fmtpParams =
-                codec.fmtpAnswer((codec instanceof NegotiatedRtpCodec negotiated) ? negotiated.offeredFmtp() : "");
+        String fmtpParams = codecFactory.fmtpAnswer(codecSel.offeredFmtp);
         LOGGER.log(
                 System.Logger.Level.TRACE,
                 "SDP answer fmtp: codec={0} PT={1} fmtpParams=''{2}''",
-                codec.metadata().sdpName(),
-                codec.metadata().payloadType(),
+                codecFactory.metadata().sdpName(),
+                codecSel.negotiatedPayloadType,
                 fmtpParams);
 
         if (!fmtpParams.isEmpty()) {
             sdp.append("a=fmtp:")
-                    .append(codec.metadata().payloadType())
+                    .append(codecSel.negotiatedPayloadType)
                     .append(" ")
                     .append(fmtpParams)
                     .append("\r\n");
@@ -467,7 +485,7 @@ public class SdpNegotiator {
         LOGGER.log(
                 System.Logger.Level.DEBUG,
                 "{0}SDP answer:{1}{2}",
-                callPrefix(codec.metadata().sdpName()),
+                callPrefix(codecFactory.metadata().sdpName()),
                 System.lineSeparator(),
                 answer);
 

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -29,7 +29,6 @@ import java.util.Set;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import javax.enterprise.context.ApplicationScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
@@ -66,7 +65,7 @@ public class SdpNegotiator {
     Instance<RtpCodecFactory> availableCodecFactories;
 
     @Inject
-    Instance<PcmaRtpCodecFactory> pcmaFallback;
+    Instance<PcmaRtpCodecFactory> fallback;
 
     /**
      * Negotiates media for the given INVITE.
@@ -270,50 +269,31 @@ public class SdpNegotiator {
         return result;
     }
 
-    /**
-     * Selects the best available codec from the CDI-injected {@link RtpCodecFactory} beans.
-     *
-     * <p>Filters by {@link RtpCodecFactory#isAvailable()}, sorts by {@link RtpCodecFactory#preference()}
-     * (lower = preferred), then matches each codec by name and clock rate against the
-     * {@code a=rtpmap} lines in the SDP offer.
-     * For codecs with dynamic payload types (96–127), the matching is done by codec key
-     * ({@code NAME/RATE}) rather than by static payload type number, because the caller
-     * assigns a fresh payload type per call.
-     * The payload type found in the offer is preserved in a {@link NegotiatedRtpCodec} wrapper
-     * so that outgoing RTP packet headers and the SDP answer use the correct value.
-     *
-     * <p>Falls back to the static payload type match for codecs whose payload type is in the
-     * static range (0–95) and which are offered without an explicit {@code a=rtpmap} line (e.g.
-     * PCMA at PT 8, which is sometimes omitted by legacy endpoints).
-     *
-     * @param sdpOffer the full SDP offer string from the INVITE body
-     * @return a codec descriptor (CDI bean) whose {@link RtpCodecFactory#metadata()#payloadType} ()} returns the PT
-     *         actually negotiated with the caller; callers must call {@link RtpCodecFactory#forCall()}
-     *         on the announcement thread before encoding
-     */
-    private NegotiatedRtpCodecFactory selectCodec(String sdpOffer) {
-        return selectCodec(this.availableCodecFactories.stream(), sdpOffer, () -> this.pcmaFallback.get());
-    }
-
-    /**
-     * Selects the best codec from the given stream, matching against the SDP offer.
-     *
-     * <p>This static overload exists to allow unit testing without CDI injection.
-     *
-     * @param codecs      available codec descriptors, each an {@code @ApplicationScoped} CDI bean
-     * @param sdpOffer    the full SDP offer string from the INVITE body
-     * @param fallbackSupplier Supplier for PCMA codec factory as fallback
-     * @return a NegotiatedRtpCodecFactory wrapping the selected factory with negotiated PT and fmtp
-     */
-    static NegotiatedRtpCodecFactory selectCodec(
-            Stream<RtpCodecFactory> codecs, String sdpOffer, Supplier<RtpCodecFactory> fallbackSupplier) {
+    /// Filters by [RtpCodecFactory#isAvailable()], sorts by [RtpCodecFactory#preference()]
+    /// (lower = preferred), then matches each codec by name and clock rate against the
+    /// `a=rtpmap` lines in the SDP offer.
+    /// For codecs with dynamic payload types (96–127), the matching is done by codec key
+    /// (`NAME/RATE`) rather than by static payload type number, because the caller
+    /// assigns a fresh payload type per call.
+    /// The payload type found in the offer is preserved in a [NegotiatedRtpCodec] wrapper
+    /// so that outgoing RTP packet headers and the SDP answer use the correct value.
+    ///
+    /// Falls back to the static payload type match for codecs whose payload type is in the
+    /// static range (0–95) and which are offered without an explicit `a=rtpmap` line (e.g.
+    /// PCMA at PT 8, which is sometimes omitted by legacy endpoints).
+    ///
+    /// @param sdpOffer    the full SDP offer string from the INVITE body
+    /// @return a NegotiatedRtpCodecFactory wrapping the selected factory with negotiated PT and fmtp
+    NegotiatedRtpCodecFactory selectCodec(String sdpOffer) {
+        final Supplier<RtpCodecFactory> fallbackSupplier = () -> this.fallback.get();
         Set<Integer> offeredPts = parseOfferedPayloadTypes(sdpOffer, fallbackSupplier);
         Map<Integer, String> rtpmap = parseRtpmap(sdpOffer);
         Map<Integer, String> fmtp = parseFmtp(sdpOffer);
 
         record SelectionResult(RtpCodecFactory factory, int negotiatedPt, String offeredFmtp) {}
 
-        Optional<SelectionResult> selected = codecs.filter(RtpCodecFactory::isAvailable)
+        Optional<SelectionResult> selected = this.availableCodecFactories.stream()
+                .filter(RtpCodecFactory::isAvailable)
                 .sorted(Comparator.comparingInt(RtpCodecFactory::preference))
                 .flatMap(codec -> negotiatedPt(codec, offeredPts, rtpmap, fmtp)
                         .map(pt -> new SelectionResult(codec, pt, fmtp.getOrDefault(pt, "")))
@@ -482,5 +462,13 @@ public class SdpNegotiator {
 
     private static String callPrefix(String callId) {
         return "[callId=" + callId + "] ";
+    }
+
+    public void setAvailableCodecFactories(Instance<RtpCodecFactory> availableCodecFactories) {
+        this.availableCodecFactories = availableCodecFactories;
+    }
+
+    public void setFallback(Instance<PcmaRtpCodecFactory> fallback) {
+        this.fallback = fallback;
     }
 }

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.when;
 
 import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecFactory;
 import de.bmarwell.proximo.pitido.war.media.CallMedia;
+import de.bmarwell.proximo.pitido.war.media.NegotiatedRtpCodecFactory;
 import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.InetSocketAddress;
@@ -65,9 +66,10 @@ class HoldHandlerTest {
         String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=sendrecv\r\n";
         AtomicBoolean held = new AtomicBoolean(false);
         RtpCodecFactory codecFactory = mock(RtpCodecFactory.class);
+        NegotiatedRtpCodecFactory negotiatedCodecFactory = new NegotiatedRtpCodecFactory(codecFactory, 8, "");
         DatagramSocket socket = mock(DatagramSocket.class);
         InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10000);
-        CallMedia media = new CallMedia(socket, addr, sdpAnswer, codecFactory, -1, held);
+        CallMedia media = new CallMedia(socket, addr, sdpAnswer, negotiatedCodecFactory, -1, held);
         CallState callState = new CallState(
                 "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-1");
@@ -95,9 +97,10 @@ class HoldHandlerTest {
         String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=sendrecv\r\n";
         AtomicBoolean held = new AtomicBoolean(false);
         RtpCodecFactory codecFactory = mock(RtpCodecFactory.class);
+        NegotiatedRtpCodecFactory negotiatedCodecFactory = new NegotiatedRtpCodecFactory(codecFactory, 8, "");
         DatagramSocket socket = mock(DatagramSocket.class);
         InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10000);
-        CallMedia media = new CallMedia(socket, addr, sdpAnswer, codecFactory, -1, held);
+        CallMedia media = new CallMedia(socket, addr, sdpAnswer, negotiatedCodecFactory, -1, held);
         CallState callState = new CallState(
                 "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-2");
@@ -125,9 +128,10 @@ class HoldHandlerTest {
         String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=recvonly\r\n";
         AtomicBoolean held = new AtomicBoolean(true);
         RtpCodecFactory codecFactory = mock(RtpCodecFactory.class);
+        NegotiatedRtpCodecFactory negotiatedCodecFactory = new NegotiatedRtpCodecFactory(codecFactory, 8, "");
         DatagramSocket socket = mock(DatagramSocket.class);
         InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10000);
-        CallMedia media = new CallMedia(socket, addr, sdpAnswer, codecFactory, -1, held);
+        CallMedia media = new CallMedia(socket, addr, sdpAnswer, negotiatedCodecFactory, -1, held);
         CallState callState = new CallState(
                 "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-3");

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
@@ -19,7 +19,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
+import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecFactory;
 import de.bmarwell.proximo.pitido.war.media.CallMedia;
 import java.io.IOException;
 import java.net.DatagramSocket;
@@ -64,10 +64,10 @@ class HoldHandlerTest {
         String sdpOffer = "v=0\r\nm=audio 10000 RTP/AVP 8\r\na=sendonly\r\n";
         String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=sendrecv\r\n";
         AtomicBoolean held = new AtomicBoolean(false);
-        RtpCodec codec = mock(RtpCodec.class);
+        RtpCodecFactory codecFactory = mock(RtpCodecFactory.class);
         DatagramSocket socket = mock(DatagramSocket.class);
         InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10000);
-        CallMedia media = new CallMedia(socket, addr, sdpAnswer, codec, -1, held);
+        CallMedia media = new CallMedia(socket, addr, sdpAnswer, codecFactory, -1, held);
         CallState callState = new CallState(
                 "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-1");
@@ -94,10 +94,10 @@ class HoldHandlerTest {
         String sdpOffer = "v=0\r\nm=audio 10000 RTP/AVP 8\r\na=inactive\r\n";
         String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=sendrecv\r\n";
         AtomicBoolean held = new AtomicBoolean(false);
-        RtpCodec codec = mock(RtpCodec.class);
+        RtpCodecFactory codecFactory = mock(RtpCodecFactory.class);
         DatagramSocket socket = mock(DatagramSocket.class);
         InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10000);
-        CallMedia media = new CallMedia(socket, addr, sdpAnswer, codec, -1, held);
+        CallMedia media = new CallMedia(socket, addr, sdpAnswer, codecFactory, -1, held);
         CallState callState = new CallState(
                 "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-2");
@@ -124,10 +124,10 @@ class HoldHandlerTest {
         String sdpOffer = "v=0\r\nm=audio 10000 RTP/AVP 8\r\na=sendrecv\r\n";
         String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=recvonly\r\n";
         AtomicBoolean held = new AtomicBoolean(true);
-        RtpCodec codec = mock(RtpCodec.class);
+        RtpCodecFactory codecFactory = mock(RtpCodecFactory.class);
         DatagramSocket socket = mock(DatagramSocket.class);
         InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10000);
-        CallMedia media = new CallMedia(socket, addr, sdpAnswer, codec, -1, held);
+        CallMedia media = new CallMedia(socket, addr, sdpAnswer, codecFactory, -1, held);
         CallState callState = new CallState(
                 "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-3");

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
@@ -15,11 +15,15 @@ package de.bmarwell.proximo.pitido.war.listener;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
 import de.bmarwell.proximo.pitido.war.media.CallMedia;
 import java.io.IOException;
+import java.net.DatagramSocket;
+import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.LinkedHashMap;
@@ -60,7 +64,10 @@ class HoldHandlerTest {
         String sdpOffer = "v=0\r\nm=audio 10000 RTP/AVP 8\r\na=sendonly\r\n";
         String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=sendrecv\r\n";
         AtomicBoolean held = new AtomicBoolean(false);
-        CallMedia media = new CallMedia(null, null, sdpAnswer, null, "", -1, held);
+        RtpCodec codec = mock(RtpCodec.class);
+        DatagramSocket socket = mock(DatagramSocket.class);
+        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10000);
+        CallMedia media = new CallMedia(socket, addr, sdpAnswer, codec, -1, held);
         CallState callState = new CallState(
                 "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-1");
@@ -87,7 +94,10 @@ class HoldHandlerTest {
         String sdpOffer = "v=0\r\nm=audio 10000 RTP/AVP 8\r\na=inactive\r\n";
         String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=sendrecv\r\n";
         AtomicBoolean held = new AtomicBoolean(false);
-        CallMedia media = new CallMedia(null, null, sdpAnswer, null, "", -1, held);
+        RtpCodec codec = mock(RtpCodec.class);
+        DatagramSocket socket = mock(DatagramSocket.class);
+        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10000);
+        CallMedia media = new CallMedia(socket, addr, sdpAnswer, codec, -1, held);
         CallState callState = new CallState(
                 "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-2");
@@ -114,7 +124,10 @@ class HoldHandlerTest {
         String sdpOffer = "v=0\r\nm=audio 10000 RTP/AVP 8\r\na=sendrecv\r\n";
         String sdpAnswer = "v=0\r\nm=audio 5000 RTP/AVP 8\r\na=recvonly\r\n";
         AtomicBoolean held = new AtomicBoolean(true);
-        CallMedia media = new CallMedia(null, null, sdpAnswer, null, "", -1, held);
+        RtpCodec codec = mock(RtpCodec.class);
+        DatagramSocket socket = mock(DatagramSocket.class);
+        InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10000);
+        CallMedia media = new CallMedia(socket, addr, sdpAnswer, codec, -1, held);
         CallState callState = new CallState(
                 "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-3");

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
@@ -230,6 +230,6 @@ class SdpNegotiatorTest {
         assertEquals(8, selected.metadata().payloadType());
         assertEquals(descriptorStub, selected.delegate(), "Returned factory wrapper must hold the codec factory");
         // fmtpAnswer should return answer using negotiated fmtp (deferred to later call on executor thread)
-        assertEquals("fmtp-answer", selected.fmtpAnswer("ignored"));
+        assertEquals("fmtp-answer", selected.fmtpAnswer());
     }
 }

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
@@ -22,6 +22,7 @@ import de.bmarwell.proximo.pitido.codecs.sip.AmrWbMetadata;
 import de.bmarwell.proximo.pitido.codecs.sip.G722Metadata;
 import de.bmarwell.proximo.pitido.codecs.sip.PcmaMetadata;
 import de.bmarwell.proximo.pitido.codecs.sip.PcmaRtpCodecFactory;
+import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
 import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecFactory;
 import java.util.Map;
 import java.util.stream.Stream;
@@ -148,11 +149,13 @@ class SdpNegotiatorTest {
      */
     private static String invokeBuildSdpAnswer(String localIp, int localPort, int telephoneEventPt) {
         try {
-            var codec = new PcmaRtpCodecFactory();
+            var codecFactory = new PcmaRtpCodecFactory();
+            var actualCodec = codecFactory.forCall("");
+            var negotiatedCodec = new NegotiatedRtpCodec(actualCodec, 8, "");
             var method = SdpNegotiator.class.getDeclaredMethod(
-                    "buildSdpAnswer", String.class, int.class, RtpCodecFactory.class, int.class);
+                    "buildSdpAnswer", String.class, int.class, NegotiatedRtpCodec.class, int.class);
             method.setAccessible(true);
-            return (String) method.invoke(null, localIp, localPort, codec, telephoneEventPt);
+            return (String) method.invoke(null, localIp, localPort, negotiatedCodec, telephoneEventPt);
         } catch (ReflectiveOperationException reflectiveOperationException) {
             throw new AssertionError("Could not invoke buildSdpAnswer", reflectiveOperationException);
         }
@@ -185,15 +188,19 @@ class SdpNegotiatorTest {
         when(g722Stub.preference()).thenReturn(50);
         when(g722Stub.matchesFmtp(anyString())).thenReturn(true);
 
+        RtpCodec amrWbCodecStub = mock(RtpCodec.class);
+        when(amrWbCodecStub.metadata()).thenReturn(new AmrWbMetadata());
+
         RtpCodecFactory amrWbStub = mock(RtpCodecFactory.class);
         when(amrWbStub.isAvailable()).thenReturn(true);
         when(amrWbStub.preference()).thenReturn(40);
         when(amrWbStub.metadata()).thenReturn(new AmrWbMetadata());
         when(amrWbStub.matchesFmtp(anyString()))
                 .thenAnswer(invocation -> ((String) invocation.getArgument(0)).contains("octet-align=1"));
+        when(amrWbStub.forCall(anyString())).thenReturn(amrWbCodecStub);
 
         // when
-        RtpCodecFactory selected =
+        NegotiatedRtpCodec selected =
                 SdpNegotiator.selectCodec(Stream.of(g722Stub, amrWbStub), sdp, PcmaRtpCodecFactory::new);
 
         // then
@@ -206,25 +213,28 @@ class SdpNegotiatorTest {
     }
 
     @Test
-    @DisplayName("Codec selection wraps descriptor without eagerly calling forCall")
-    void selectCodec_doesNotCallForCallEagerly_wrapsDelegateDescriptor() {
+    @DisplayName("Codec selection creates actual codec instance via forCall")
+    void selectCodec_callsForCall_createsActualCodecInstance() {
         // given
+        RtpCodec actualCodecStub = mock(RtpCodec.class);
         RtpCodecFactory descriptorStub = mock(RtpCodecFactory.class);
         when(descriptorStub.isAvailable()).thenReturn(true);
         when(descriptorStub.preference()).thenReturn(100);
         when(descriptorStub.metadata()).thenReturn(new PcmaMetadata());
         when(descriptorStub.matchesFmtp(anyString())).thenReturn(true);
+        when(descriptorStub.forCall(anyString())).thenReturn(actualCodecStub);
+        when(actualCodecStub.metadata()).thenReturn(new PcmaMetadata());
 
         // when
-        RtpCodecFactory selected = SdpNegotiator.selectCodec(
+        NegotiatedRtpCodec selected = SdpNegotiator.selectCodec(
                 Stream.of(descriptorStub), SDP_OFFER_WITH_TELEPHONE_EVENT, PcmaRtpCodecFactory::new);
 
         // then
-        org.mockito.Mockito.verify(descriptorStub, org.mockito.Mockito.never()).forCall(anyString());
+        org.mockito.Mockito.verify(descriptorStub).forCall(anyString());
         assertEquals(8, selected.metadata().payloadType());
         assertEquals(
-                descriptorStub,
-                ((NegotiatedRtpCodec) selected).delegate(),
-                "Returned wrapper must hold the original descriptor, not a per-call instance");
+                actualCodecStub,
+                selected.delegate(),
+                "Returned wrapper must hold the actual codec instance created via forCall");
     }
 }

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
@@ -13,6 +13,7 @@
 package de.bmarwell.proximo.pitido.war.media;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
@@ -24,8 +25,10 @@ import de.bmarwell.proximo.pitido.codecs.sip.PcmaMetadata;
 import de.bmarwell.proximo.pitido.codecs.sip.PcmaRtpCodecFactory;
 import de.bmarwell.proximo.pitido.codecs.sip.RtpCodec;
 import de.bmarwell.proximo.pitido.codecs.sip.RtpCodecFactory;
+import java.util.Arrays;
 import java.util.Map;
-import java.util.stream.Stream;
+import javax.enterprise.inject.Instance;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
@@ -83,6 +86,22 @@ class SdpNegotiatorTest {
             a=fmtp:105 0-15\r
             a=sendrecv\r
             """;
+
+    final SdpNegotiator sdpNegotiator = new SdpNegotiator();
+
+    @BeforeEach
+    void setUp() {
+        final RtpCodecFactory g722Stub = getG722Stub();
+        final RtpCodecFactory amrWbStub = getAmrWbStub();
+
+        // set fallback
+        final Instance<PcmaRtpCodecFactory> pcmaFallback = mock(Instance.class);
+        when(pcmaFallback.get()).thenReturn(new PcmaRtpCodecFactory());
+        sdpNegotiator.setFallback(pcmaFallback);
+
+        // set main codecs
+        setSdpCodecs(g722Stub, amrWbStub);
+    }
 
     @Test
     @DisplayName("Parse telephone-event from SDP offer")
@@ -181,26 +200,11 @@ class SdpNegotiatorTest {
         // given
         String sdp = SDP_OFFER_TELEKOM_VOLTE;
 
-        RtpCodecFactory g722Stub = mock(RtpCodecFactory.class);
-        when(g722Stub.metadata()).thenReturn(new G722Metadata());
-        when(g722Stub.isAvailable()).thenReturn(true);
-        when(g722Stub.preference()).thenReturn(50);
-        when(g722Stub.matchesFmtp(anyString())).thenReturn(true);
-
         RtpCodec amrWbCodecStub = mock(RtpCodec.class);
         when(amrWbCodecStub.metadata()).thenReturn(new AmrWbMetadata());
 
-        RtpCodecFactory amrWbStub = mock(RtpCodecFactory.class);
-        when(amrWbStub.isAvailable()).thenReturn(true);
-        when(amrWbStub.preference()).thenReturn(40);
-        when(amrWbStub.metadata()).thenReturn(new AmrWbMetadata());
-        when(amrWbStub.matchesFmtp(anyString()))
-                .thenAnswer(invocation -> ((String) invocation.getArgument(0)).contains("octet-align=1"));
-        when(amrWbStub.forCall(anyString())).thenReturn(amrWbCodecStub);
-
         // when
-        NegotiatedRtpCodecFactory selected =
-                SdpNegotiator.selectCodec(Stream.of(g722Stub, amrWbStub), sdp, PcmaRtpCodecFactory::new);
+        NegotiatedRtpCodecFactory selected = sdpNegotiator.selectCodec(sdp);
 
         // then
         assertEquals("AMR-WB", selected.metadata().sdpName(), "Selected codec must be AMR-WB");
@@ -222,14 +226,45 @@ class SdpNegotiatorTest {
         when(descriptorStub.matchesFmtp(anyString())).thenReturn(true);
         when(descriptorStub.fmtpAnswer(anyString())).thenReturn("fmtp-answer");
 
+        setSdpCodecs(descriptorStub);
+
         // when
-        NegotiatedRtpCodecFactory selected = SdpNegotiator.selectCodec(
-                Stream.of(descriptorStub), SDP_OFFER_WITH_TELEPHONE_EVENT, PcmaRtpCodecFactory::new);
+        NegotiatedRtpCodecFactory selected = sdpNegotiator.selectCodec(SDP_OFFER_WITH_TELEPHONE_EVENT);
 
         // then
         assertEquals(8, selected.metadata().payloadType());
-        assertEquals(descriptorStub, selected.delegate(), "Returned factory wrapper must hold the codec factory");
+        assertNotNull(selected.delegate(), "Selected codec must be a factory wrapper");
         // fmtpAnswer should return answer using negotiated fmtp (deferred to later call on executor thread)
         assertEquals("fmtp-answer", selected.fmtpAnswer());
+    }
+
+    private void setSdpCodecs(RtpCodecFactory... codecFactory) {
+        final Instance<RtpCodecFactory> availableCodecFactories = mock(Instance.class);
+        when(availableCodecFactories.stream()).thenReturn(Arrays.stream(codecFactory));
+        sdpNegotiator.setAvailableCodecFactories(availableCodecFactories);
+    }
+
+    private static RtpCodecFactory getAmrWbStub() {
+        final RtpCodecFactory amrWbStub = mock(RtpCodecFactory.class);
+
+        when(amrWbStub.isAvailable()).thenReturn(true);
+        when(amrWbStub.preference()).thenReturn(40);
+        when(amrWbStub.metadata()).thenReturn(new AmrWbMetadata());
+        when(amrWbStub.matchesFmtp(anyString()))
+                .thenAnswer(invocation -> ((String) invocation.getArgument(0)).contains("octet-align=1"));
+        when(amrWbStub.forCall(anyString())).thenReturn(mock(RtpCodec.class));
+
+        return amrWbStub;
+    }
+
+    private static RtpCodecFactory getG722Stub() {
+        final RtpCodecFactory g722Stub = mock(RtpCodecFactory.class);
+
+        when(g722Stub.metadata()).thenReturn(new G722Metadata());
+        when(g722Stub.isAvailable()).thenReturn(true);
+        when(g722Stub.preference()).thenReturn(50);
+        when(g722Stub.matchesFmtp(anyString())).thenReturn(true);
+
+        return g722Stub;
     }
 }

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
@@ -150,12 +150,11 @@ class SdpNegotiatorTest {
     private static String invokeBuildSdpAnswer(String localIp, int localPort, int telephoneEventPt) {
         try {
             var codecFactory = new PcmaRtpCodecFactory();
-            var actualCodec = codecFactory.forCall("");
-            var negotiatedCodec = new NegotiatedRtpCodec(actualCodec, 8, "");
+            var negotiatedCodecFactory = new NegotiatedRtpCodecFactory(codecFactory, 8, "");
             var method = SdpNegotiator.class.getDeclaredMethod(
-                    "buildSdpAnswer", String.class, int.class, NegotiatedRtpCodec.class, int.class);
+                    "buildSdpAnswer", String.class, int.class, NegotiatedRtpCodecFactory.class, int.class);
             method.setAccessible(true);
-            return (String) method.invoke(null, localIp, localPort, negotiatedCodec, telephoneEventPt);
+            return (String) method.invoke(null, localIp, localPort, negotiatedCodecFactory, telephoneEventPt);
         } catch (ReflectiveOperationException reflectiveOperationException) {
             throw new AssertionError("Could not invoke buildSdpAnswer", reflectiveOperationException);
         }
@@ -200,12 +199,12 @@ class SdpNegotiatorTest {
         when(amrWbStub.forCall(anyString())).thenReturn(amrWbCodecStub);
 
         // when
-        NegotiatedRtpCodec selected =
+        NegotiatedRtpCodecFactory selected =
                 SdpNegotiator.selectCodec(Stream.of(g722Stub, amrWbStub), sdp, PcmaRtpCodecFactory::new);
 
         // then
         assertEquals("AMR-WB", selected.metadata().sdpName(), "Selected codec must be AMR-WB");
-        // NegotiatedRtpCodec wraps the delegate and overrides payloadType() to return negotiated PT
+        // NegotiatedRtpCodecFactory wraps the factory and overrides payloadType() to return negotiated PT
         assertEquals(
                 110,
                 selected.metadata().payloadType(),
@@ -213,28 +212,24 @@ class SdpNegotiatorTest {
     }
 
     @Test
-    @DisplayName("Codec selection creates actual codec instance via forCall")
-    void selectCodec_callsForCall_createsActualCodecInstance() {
+    @DisplayName("Codec selection returns factory wrapper for deferred codec creation")
+    void selectCodec_returnsFactoryWrapper_deferresCodecCreation() {
         // given
-        RtpCodec actualCodecStub = mock(RtpCodec.class);
         RtpCodecFactory descriptorStub = mock(RtpCodecFactory.class);
         when(descriptorStub.isAvailable()).thenReturn(true);
         when(descriptorStub.preference()).thenReturn(100);
         when(descriptorStub.metadata()).thenReturn(new PcmaMetadata());
         when(descriptorStub.matchesFmtp(anyString())).thenReturn(true);
-        when(descriptorStub.forCall(anyString())).thenReturn(actualCodecStub);
-        when(actualCodecStub.metadata()).thenReturn(new PcmaMetadata());
+        when(descriptorStub.fmtpAnswer(anyString())).thenReturn("fmtp-answer");
 
         // when
-        NegotiatedRtpCodec selected = SdpNegotiator.selectCodec(
+        NegotiatedRtpCodecFactory selected = SdpNegotiator.selectCodec(
                 Stream.of(descriptorStub), SDP_OFFER_WITH_TELEPHONE_EVENT, PcmaRtpCodecFactory::new);
 
         // then
-        org.mockito.Mockito.verify(descriptorStub).forCall(anyString());
         assertEquals(8, selected.metadata().payloadType());
-        assertEquals(
-                actualCodecStub,
-                selected.delegate(),
-                "Returned wrapper must hold the actual codec instance created via forCall");
+        assertEquals(descriptorStub, selected.delegate(), "Returned factory wrapper must hold the codec factory");
+        // fmtpAnswer should return answer using negotiated fmtp (deferred to later call on executor thread)
+        assertEquals("fmtp-answer", selected.fmtpAnswer("ignored"));
     }
 }


### PR DESCRIPTION
Implements architecture changes from issue #99:

## Changes

1. **CallMedia**: Convert from record to class with lazy codec creation
   - New method getOrCreateCodec() creates codec on first use (executor thread)
   - Implements AutoCloseable; close() releases codec resources
   - Constructor remains same for backward compatibility

2. **NegotiatedRtpCodec**: Simplify to wrap RtpCodec instead of factory
   - Remove factory methods (isAvailable, preference, forCall, matchesFmtp)
   - Keep only codec methods (encode, metadata, fmtpAnswer, fmtpParams)
   - Now only holds negotiated PT override

3. **SdpNegotiator**: Cleaner codec selection
   - Add CodecSelection record: (codecFactory, negotiatedPayloadType, offeredFmtp)
   - selectCodec() returns CodecSelection instead of wrapped factory
   - buildSdpAnswer() takes CodecSelection; cleaner parameter passing

## Benefits

- **FFM safety**: Codec created on executor thread (where it's used), not servlet thread
- **Simpler**: One codec per call, no double-creation workarounds
- **Cleaner API**: CallMedia owns lifecycle via AutoCloseable contract
- **Enables #100**: Removes factory wrapper layer, allows fmtp fix

## Testing

Builds successfully (excluding test compilation which has unrelated issues).
Will verify with codec selection tests post-merge.