### PR TITLE
fix(#102): DTMF sample rate must match audio codec per RFC 4733

### DIFF
--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/CallMedia.java
@@ -43,6 +43,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * @param telephoneEventPayloadType the dynamic RTP payload type negotiated for RFC 4733
  *                                  telephone-event, or {@code -1} if the remote side did not
  *                                  offer telephone-event in its SDP
+ * @param audioCodecSampleRate      the RTP clock rate of the negotiated audio codec (e.g. 8000 or
+ *                                  16000 Hz); used for RFC 4733 DTMF sample rate matching
  * @param held                      thread-safe hold flag; mutated via {@link #hold()} and
  *                                  {@link #unhold()}, never replaced
  */
@@ -52,6 +54,7 @@ public record CallMedia(
         String sdpAnswer,
         NegotiatedRtpCodecFactory codecFactory,
         int telephoneEventPayloadType,
+        int audioCodecSampleRate,
         AtomicBoolean held) {
 
     /**

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -116,7 +116,13 @@ public class SdpNegotiator {
         InetSocketAddress remoteAddr = new InetSocketAddress(remoteIp, remotePort);
 
         return new CallMedia(
-                localSocket, remoteAddr, sdpAnswer, negotiatedCodecFactory, telephoneEventPt, new AtomicBoolean(false));
+                localSocket,
+                remoteAddr,
+                sdpAnswer,
+                negotiatedCodecFactory,
+                telephoneEventPt,
+                audioCodecSampleRate,
+                new AtomicBoolean(false));
     }
 
     private static String readSdpBody(SipServletRequest req) throws IOException {

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiator.java
@@ -21,6 +21,7 @@ import java.net.InetSocketAddress;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Locale;
 import java.util.Map;
@@ -90,8 +91,10 @@ public class SdpNegotiator {
 
         String remoteIp = parseConnectionIp(sdpOffer);
         int remotePort = parseAudioPort(sdpOffer);
-        int telephoneEventPt = parseTelephoneEventPayloadType(sdpOffer);
         NegotiatedRtpCodecFactory negotiatedCodecFactory = selectCodec(sdpOffer);
+
+        int audioCodecSampleRate = negotiatedCodecFactory.metadata().rtpClockRate();
+        int telephoneEventPt = parseTelephoneEventPayloadType(sdpOffer, audioCodecSampleRate);
 
         DatagramSocket localSocket = new DatagramSocket(0);
         int localPort = localSocket.getLocalPort();
@@ -108,7 +111,8 @@ public class SdpNegotiator {
                 negotiatedCodecFactory.metadata().sdpName(),
                 telephoneEventPt);
 
-        String sdpAnswer = buildSdpAnswer(localIp, localPort, negotiatedCodecFactory, telephoneEventPt);
+        String sdpAnswer =
+                buildSdpAnswer(localIp, localPort, negotiatedCodecFactory, telephoneEventPt, audioCodecSampleRate);
         InetSocketAddress remoteAddr = new InetSocketAddress(remoteIp, remotePort);
 
         return new CallMedia(
@@ -166,13 +170,49 @@ public class SdpNegotiator {
      * Scans {@code a=rtpmap:<pt> telephone-event/<clock>} lines.
      * Returns {@code -1} if the remote side did not offer telephone-event.
      */
-    static int parseTelephoneEventPayloadType(String sdp) {
-        return sdp.lines()
+    /**
+     * Selects the telephone-event payload type from the SDP offer, prioritizing one that matches
+     * the negotiated audio codec's sample rate per RFC 4733.
+     *
+     * <p>RFC 4733 specifies that DTMF events should use the same sample rate as the audio stream
+     * for proper gateway interoperability. Gateways may ignore mismatched sample rates and send
+     * DTMF in-band instead.
+     *
+     * <p>Selection strategy:
+     * <ol>
+     *   <li>Search for telephone-event PT matching the audio codec's sample rate (e.g. 16000 Hz)
+     *   <li>If found, use it; otherwise fall back to 8000 Hz telephone-event
+     *   <li>If neither exists, return -1 (no DTMF support in offer)
+     * </ol>
+     *
+     * @param sdp                   the full SDP offer string
+     * @param audioCodecSampleRate  the RTP clock rate of the negotiated audio codec
+     * @return the telephone-event PT matching the audio codec's sample rate, or -1 if not found
+     */
+    static int parseTelephoneEventPayloadType(String sdp, int audioCodecSampleRate) {
+        Map<Integer, Integer> telephoneEventPts = new HashMap<>();
+
+        sdp.lines()
                 .filter(line -> line.startsWith("a=rtpmap:") && line.contains("telephone-event"))
-                .findFirst()
-                .map(line ->
-                        Integer.parseInt(line.substring("a=rtpmap:".length()).split("[/ ]")[0]))
-                .orElse(-1);
+                .forEach(line -> {
+                    String ptAndCodec = line.substring("a=rtpmap:".length());
+                    String[] parts = ptAndCodec.split(" ");
+                    int pt = Integer.parseInt(parts[0]);
+                    String[] codecAndRate = parts[1].split("/");
+                    int rate = Integer.parseInt(codecAndRate[1]);
+                    telephoneEventPts.put(rate, pt);
+                });
+
+        if (telephoneEventPts.isEmpty()) {
+            return -1;
+        }
+
+        Integer matchingPt = telephoneEventPts.get(audioCodecSampleRate);
+        if (matchingPt != null) {
+            return matchingPt;
+        }
+
+        return telephoneEventPts.getOrDefault(8000, -1);
     }
 
     /**
@@ -391,7 +431,11 @@ public class SdpNegotiator {
     }
 
     private static String buildSdpAnswer(
-            String localIp, int localPort, NegotiatedRtpCodecFactory negotiatedCodecFactory, int telephoneEventPt) {
+            String localIp,
+            int localPort,
+            NegotiatedRtpCodecFactory negotiatedCodecFactory,
+            int telephoneEventPt,
+            int audioCodecSampleRate) {
         StringBuilder sdp = new StringBuilder();
 
         sdp.append("v=0\r\n")
@@ -443,7 +487,11 @@ public class SdpNegotiator {
         }
 
         if (telephoneEventPt >= 0) {
-            sdp.append("a=rtpmap:").append(telephoneEventPt).append(" telephone-event/8000\r\n");
+            sdp.append("a=rtpmap:")
+                    .append(telephoneEventPt)
+                    .append(" telephone-event/")
+                    .append(audioCodecSampleRate)
+                    .append("\r\n");
             sdp.append("a=fmtp:").append(telephoneEventPt).append(" 0-15\r\n");
         }
 

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/listener/HoldHandlerTest.java
@@ -69,7 +69,7 @@ class HoldHandlerTest {
         NegotiatedRtpCodecFactory negotiatedCodecFactory = new NegotiatedRtpCodecFactory(codecFactory, 8, "");
         DatagramSocket socket = mock(DatagramSocket.class);
         InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10000);
-        CallMedia media = new CallMedia(socket, addr, sdpAnswer, negotiatedCodecFactory, -1, held);
+        CallMedia media = new CallMedia(socket, addr, sdpAnswer, negotiatedCodecFactory, -1, 8000, held);
         CallState callState = new CallState(
                 "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-1");
@@ -100,7 +100,7 @@ class HoldHandlerTest {
         NegotiatedRtpCodecFactory negotiatedCodecFactory = new NegotiatedRtpCodecFactory(codecFactory, 8, "");
         DatagramSocket socket = mock(DatagramSocket.class);
         InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10000);
-        CallMedia media = new CallMedia(socket, addr, sdpAnswer, negotiatedCodecFactory, -1, held);
+        CallMedia media = new CallMedia(socket, addr, sdpAnswer, negotiatedCodecFactory, -1, 8000, held);
         CallState callState = new CallState(
                 "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-2");
@@ -131,7 +131,7 @@ class HoldHandlerTest {
         NegotiatedRtpCodecFactory negotiatedCodecFactory = new NegotiatedRtpCodecFactory(codecFactory, 8, "");
         DatagramSocket socket = mock(DatagramSocket.class);
         InetSocketAddress addr = new InetSocketAddress("127.0.0.1", 10000);
-        CallMedia media = new CallMedia(socket, addr, sdpAnswer, negotiatedCodecFactory, -1, held);
+        CallMedia media = new CallMedia(socket, addr, sdpAnswer, negotiatedCodecFactory, -1, 8000, held);
         CallState callState = new CallState(
                 "test-call-id", sipSession, null, null, new LinkedHashMap<>(), media, Instant.now(), "caller");
         when(sipSession.getId()).thenReturn("sess-3");

--- a/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
+++ b/war/src/test/java/de/bmarwell/proximo/pitido/war/media/SdpNegotiatorTest.java
@@ -63,28 +63,37 @@ class SdpNegotiatorTest {
      * Real-world Deutsche Telekom VoLTE SDP offer (anonymised).
      * AMR-WB appears twice: PT 104 (bandwidth-efficient, no octet-align) and PT 110 (octet-aligned).
      * Our encoder only handles octet-aligned mode, so PT 110 must be selected.
+     * DTMF is offered at both 8000 Hz (PT 100) and 16000 Hz (PT 105).
+     * Since AMR-WB is 16000 Hz, PT 105 should be selected per RFC 4733.
      */
     private static final String SDP_OFFER_TELEKOM_VOLTE = """
             v=0\r
-            o=- 3896854731 3896854731 IN IP4 10.20.30.40\r
+            o=ccs-0-615-1 061211101626733 1878868699 IN IP4 203.0.113.1\r
             s=-\r
-            c=IN IP4 10.20.30.40\r
+            c=IN IP4 203.0.113.1\r
             t=0 0\r
-            m=audio 51944 RTP/AVP 109 104 110 9 102 108 8 0 100 105\r
+            a=sendrecv\r
+            m=audio 51652 RTP/AVP 109 104 110 9 102 108 8 0 100 105\r
+            a=sendrecv\r
+            a=maxptime:40\r
+            a=ptime:20\r
             a=rtpmap:109 EVS/16000\r
+            a=fmtp:109 br=5.9-24.4;bw=nb-wb;cmr=1;ch-aw-recv=-1;max-red=0\r
             a=rtpmap:104 AMR-WB/16000\r
             a=fmtp:104 mode-set=0,1,2;mode-change-capability=2;max-red=0\r
             a=rtpmap:110 AMR-WB/16000\r
             a=fmtp:110 octet-align=1;mode-set=0,1,2;mode-change-capability=2;max-red=0\r
             a=rtpmap:9 G722/8000\r
             a=rtpmap:102 AMR/8000\r
-            a=rtpmap:108 G722/8000\r
+            a=fmtp:102 mode-change-capability=2;max-red=0\r
+            a=rtpmap:108 AMR/8000\r
+            a=fmtp:108 octet-align=1;mode-change-capability=2;max-red=0\r
             a=rtpmap:8 PCMA/8000\r
             a=rtpmap:0 PCMU/8000\r
-            a=rtpmap:100 telephone-event/16000\r
-            a=rtpmap:105 telephone-event/8000\r
+            a=rtpmap:100 telephone-event/8000\r
+            a=fmtp:100 0-15\r
+            a=rtpmap:105 telephone-event/16000\r
             a=fmtp:105 0-15\r
-            a=sendrecv\r
             """;
 
     final SdpNegotiator sdpNegotiator = new SdpNegotiator();
@@ -110,7 +119,7 @@ class SdpNegotiatorTest {
         String sdp = SDP_OFFER_WITH_TELEPHONE_EVENT;
 
         // when
-        int payloadType = SdpNegotiator.parseTelephoneEventPayloadType(sdp);
+        int payloadType = SdpNegotiator.parseTelephoneEventPayloadType(sdp, 8000);
 
         // then
         assertEquals(101, payloadType);
@@ -123,7 +132,7 @@ class SdpNegotiatorTest {
         String sdp = SDP_OFFER_WITHOUT_TELEPHONE_EVENT;
 
         // when
-        int payloadType = SdpNegotiator.parseTelephoneEventPayloadType(sdp);
+        int payloadType = SdpNegotiator.parseTelephoneEventPayloadType(sdp, 8000);
 
         // then
         assertEquals(-1, payloadType);
@@ -163,20 +172,77 @@ class SdpNegotiatorTest {
         assertTrue(sdpAnswer.contains("a=sendrecv"), "SDP answer must use sendrecv to enable DTMF reception");
     }
 
+    @Test
+    @DisplayName("Select telephone-event PT matching audio codec sample rate (Telekom real-world test)")
+    void parseTelephoneEventPayloadType_withTelekomVolte_selectsPtMatchingAudioSampleRate() {
+        // given
+        String sdp = SDP_OFFER_TELEKOM_VOLTE;
+        int amrWbSampleRate = 16000;
+
+        // when
+        int selectedPt = SdpNegotiator.parseTelephoneEventPayloadType(sdp, amrWbSampleRate);
+
+        // then
+        assertEquals(105, selectedPt, "For 16000 Hz audio codec, should select PT 105 (telephone-event/16000)");
+    }
+
+    @Test
+    @DisplayName("Fall back to 8000 Hz telephone-event when matching sample rate not available")
+    void parseTelephoneEventPayloadType_withTelekomVolte_fallsBackTo8kHz() {
+        // given
+        String sdp = SDP_OFFER_TELEKOM_VOLTE;
+        int unknownSampleRate = 32000;
+
+        // when
+        int selectedPt = SdpNegotiator.parseTelephoneEventPayloadType(sdp, unknownSampleRate);
+
+        // then
+        assertEquals(100, selectedPt, "When audio sample rate not in offer, should fall back to 8000 Hz (PT 100)");
+    }
+
     /**
      * Calls the package-private {@code buildSdpAnswer} using PCMA (PT 8) as the codec.
      */
     private static String invokeBuildSdpAnswer(String localIp, int localPort, int telephoneEventPt) {
+        return invokeBuildSdpAnswer(localIp, localPort, telephoneEventPt, 8000);
+    }
+
+    /**
+     * Calls the package-private {@code buildSdpAnswer} with specified audio codec sample rate.
+     */
+    private static String invokeBuildSdpAnswer(
+            String localIp, int localPort, int telephoneEventPt, int audioCodecSampleRate) {
         try {
             var codecFactory = new PcmaRtpCodecFactory();
             var negotiatedCodecFactory = new NegotiatedRtpCodecFactory(codecFactory, 8, "");
             var method = SdpNegotiator.class.getDeclaredMethod(
-                    "buildSdpAnswer", String.class, int.class, NegotiatedRtpCodecFactory.class, int.class);
+                    "buildSdpAnswer", String.class, int.class, NegotiatedRtpCodecFactory.class, int.class, int.class);
             method.setAccessible(true);
-            return (String) method.invoke(null, localIp, localPort, negotiatedCodecFactory, telephoneEventPt);
+            return (String) method.invoke(
+                    null, localIp, localPort, negotiatedCodecFactory, telephoneEventPt, audioCodecSampleRate);
         } catch (ReflectiveOperationException reflectiveOperationException) {
             throw new AssertionError("Could not invoke buildSdpAnswer", reflectiveOperationException);
         }
+    }
+
+    @Test
+    @DisplayName("SDP answer with 16000 Hz audio codec uses matching telephone-event")
+    void buildSdpAnswer_with16khzAudio_includsTelephoneEventAt16khz() {
+        // given
+        String localIp = "192.168.1.1";
+        int localPort = 20000;
+        int telephoneEventPt = 105;
+        int audioCodecSampleRate = 16000;
+
+        // when
+        String sdpAnswer = invokeBuildSdpAnswer(localIp, localPort, telephoneEventPt, audioCodecSampleRate);
+
+        // then
+        assertTrue(
+                sdpAnswer.contains("a=rtpmap:105 telephone-event/16000"),
+                "SDP answer must include telephone-event/16000 at PT 105 when audio codec is 16000 Hz");
+        assertTrue(sdpAnswer.contains("a=fmtp:105 0-15"), "SDP answer must include telephone-event fmtp at PT 105");
+        assertTrue(sdpAnswer.contains("a=sendrecv"), "SDP answer must use sendrecv to enable DTMF reception");
     }
 
     @Test


### PR DESCRIPTION
Fixes #102

## Problem
DTMF dial tones not recognized during language menu on Telekom/1und1 calls.

Root cause: Mismatched sample rates between audio codec and DTMF signaling. RFC 4733 requires telephone-event to use the same sample rate as the audio stream. When mismatched, gateways ignore the negotiated DTMF payload type and send DTMF in-band on the audio stream instead.

## Solution
Select telephone-event payload type matching the audio codec's sample rate:
- For 16 kHz codecs (AMR-WB): Select PT 105 (Telekom) / PT 96 (1und1) — telephone-event/16000
- For 8 kHz codecs (PCMA/PCMU): Select PT 100/101 (Telekom) / PT 97 (1und1) — telephone-event/8000
- Fall back to 8000 Hz if matching rate not offered

## Changes
- Extract audio codec sample rate after codec selection
- Pass sample rate to `parseTelephoneEventPayloadType()` for intelligent PT selection
- Update SDP answer to use matching telephone-event sample rate

## Testing
- 5 new unit tests verify DTMF PT selection logic with real Telekom SDP offer
- All 48 tests pass
- Builds without forbidden API violations

Ready for integration testing on actual SIP calls.