### PR TITLE
fix: issue #104 wrap WAV decoder input stream in BufferedInputStream

### DIFF
--- a/codecs/input/src/main/java/de/bmarwell/proximo/pitido/codecs/input/WavPcmDecoder.java
+++ b/codecs/input/src/main/java/de/bmarwell/proximo/pitido/codecs/input/WavPcmDecoder.java
@@ -12,6 +12,7 @@
  */
 package de.bmarwell.proximo.pitido.codecs.input;
 
+import java.io.BufferedInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.Comparator;
@@ -92,7 +93,8 @@ public class WavPcmDecoder implements PcmDecoder {
         }
 
         try {
-            AudioInputStream raw = AudioSystem.getAudioInputStream(in);
+            InputStream bufferedStream = new BufferedInputStream(in);
+            AudioInputStream raw = AudioSystem.getAudioInputStream(bufferedStream);
             AudioFormat fmt = raw.getFormat();
 
             if ((int) fmt.getSampleRate() != REQUIRED_SAMPLE_RATE) {


### PR DESCRIPTION
## Summary

Fixes WAV audio playback failure by wrapping the classpath input stream in BufferedInputStream before passing it to AudioSystem.getAudioInputStream().

## Problem

WAV audio files fail to play with error: IOException mark/reset not supported

This affects German language pack and any other language using WAV format announcements.

Java AudioSystem.getAudioInputStream() internally calls mark() and reset() on the stream to detect audio format metadata. Classpath streams returned by ClassLoader.getResourceAsStream() are plain InputStream objects without buffering, and they do not support mark/reset operations.

## Solution

Wrap the input stream in BufferedInputStream before passing it to AudioSystem. BufferedInputStream implements mark/reset support and provides efficient buffering.

### Changes

- codecs/input: WavPcmDecoder.open() now wraps input stream in BufferedInputStream on line 96
- Added import: java.io.BufferedInputStream

## Testing

- Build: ./mvnw clean verify -am -pl codecs/input succeeds
- Forbidden APIs check: passes
- No test breakage

## Related

- Closes #104
- Related to issue 106 (infinite retry loop)

## Impact

WAV announcements (German language pack) will now play correctly without throwing stream marking errors and without entering infinite retry loops.