### PR TITLE
fix: issue #106 treat codec errors as fatal in announcement loop

### DIFF
--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/AnnouncementLoop.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/AnnouncementLoop.java
@@ -127,7 +127,16 @@ public class AnnouncementLoop {
 
             return false;
         } catch (IOException ioException) {
-            if (media.localSocket().isClosed()) {
+            boolean isClosed = media.localSocket().isClosed();
+
+            LOGGER.log(
+                    System.Logger.Level.DEBUG,
+                    "{0}Time announcement error (socket closed: {1}): {2}",
+                    SipCallHeaders.callPrefix(sessionId),
+                    isClosed,
+                    ioException.getMessage());
+
+            if (isClosed) {
                 LOGGER.log(
                         System.Logger.Level.DEBUG,
                         "{0}Announcement loop: socket closed — exiting",
@@ -138,13 +147,12 @@ public class AnnouncementLoop {
 
             LOGGER.log(
                     System.Logger.Level.WARNING,
-                    "{0}Time announcement failed for language [{1}]: {2}",
+                    "{0}Codec error in language [{1}]; treating as fatal — exiting announcement loop",
                     SipCallHeaders.callPrefix(sessionId),
                     factory.displayName(),
-                    ioException.getMessage(),
                     ioException);
 
-            return false;
+            return true;
         }
     }
 }


### PR DESCRIPTION
Fixes #106

## Problem
AnnouncementLoop was retrying announcements infinitely when codec errors occurred (like 'mark/reset not supported' from WAV stream issues). The exception was swallowed and the loop continued with `return false`, causing thousands of retries visible in the logs.

## Solution
1. **Treat codec errors as fatal**: Return `true` (exit loop) instead of `false` (retry) when an IOException occurs and the socket is still open.
2. **Add debug logging**: Log the socket status (closed vs open) when an error occurs, making it clear whether the socket was actually closed or a codec error was the cause.

## Changes
- Modified `AnnouncementLoop.playOneAnnouncement()` catch block to:
  - Check socket status first and log it at DEBUG level
  - Return `true` (exit) for any IOException when socket is open (codec error)
  - Log socket closure separately at DEBUG level
  - Log codec errors at WARNING level with full exception

## Impact
- Eliminates infinite retry loops that fill logs with repeated errors
- Provides clear diagnostic information (socket status) in logs
- Codec errors now exit cleanly instead of spinning

This is related to fixes #104 and #105 which address the root causes of codec errors (WAV stream marking and OPUS FFM thread confinement).