### PR TITLE
fix: issue #105 clear thread interrupt flag before announcement playback

### DIFF
--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/MenuRunner.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/MenuRunner.java
@@ -72,6 +72,12 @@ public class MenuRunner {
             LanguageFactory chosen = this.callSessionManager.takePendingSelection(sessionId);
 
             if (chosen != null) {
+                // Clear the interrupt flag before transitioning to announcement playback.
+                // The menu was cancelled via Future.cancel(true) when the DTMF digit arrived,
+                // which set the thread interrupt flag. We must clear it to allow the announcement
+                // to play on the same executor thread without being immediately interrupted.
+                Thread.interrupted();
+
                 this.announcementLoop.play(session, player, chosen, sessionId, media);
             } else {
                 LOGGER.log(


### PR DESCRIPTION
Closes #105

## Problem

After selecting a language via DTMF digit, the announcement playback immediately fails with 'Announcement loop interrupted', even though the menu (OPUS) played fine before the digit was pressed.

Root cause: The language selection menu is cancelled when the DTMF digit arrives via `Future.cancel(true)`. This sets the thread interrupt flag on the executor thread. When the announcement loop starts on the same executor thread, it immediately checks `Thread.currentThread().isInterrupted()` in RtpAudioPlayer.playBlocking() and throws InterruptedException without playing any audio.

The issue is NOT an OPUS decoder problem or WAV stream issue—both worked in the menu. The issue is that the thread interrupt flag from the cancelled MenuRunner was never cleared.

## Solution

Call `Thread.interrupted()` in MenuRunner's finally block before transitioning to announcementLoop.play(). The `Thread.interrupted()` method both returns the current interrupt status AND clears it for future checks.

## Why This Works

- MenuRunner catches InterruptedException → re-sets interrupt flag with `Thread.currentThread().interrupt()` (correct)
- But then it must clear the flag before handing the thread to AnnouncementLoop
- `Thread.interrupted()` is the standard way to clear the interrupt flag
- AnnouncementLoop now runs on a fresh thread state without the inherited interrupt flag

## Impact

✅ German announcements now play after selecting 1
✅ English announcements now play after selecting 2
✅ Spanish announcements now play after selecting 8
✅ All language packs work, not just single-language scenarios