### PR TITLE
fix: encoder thread FFM arena confinement violation

### DIFF
--- a/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/NativeRtpCodec.java
+++ b/codecs/sip/src/main/java/de/bmarwell/proximo/pitido/codecs/sip/NativeRtpCodec.java
@@ -25,7 +25,7 @@ public abstract class NativeRtpCodec implements RtpCodec {
     protected final Arena callArena;
 
     protected NativeRtpCodec() {
-        this.callArena = Arena.ofConfined();
+        this.callArena = Arena.ofShared();
     }
 
     /**


### PR DESCRIPTION
The async encoder thread (issue #116) runs in a different thread than the SIP call handler. FFM (Foreign Function & Memory) detected thread confinement violation when the encoder tried to access MemorySegments allocated in Arena.ofConfined() from a different thread.

Change Arena.ofConfined() → Arena.ofShared() to allow safe multi-threaded access to pre-allocated input/output segments used by the AMR-WB encoder.

WrongThreadException occurs when:
- RtpAudioPlayer.playSilence() submits encoder work to ManagedExecutorService
- Encoder thread calls codec.encode(silenceFrame)
- AmrWbRtpCodec.encode() accesses reusableInputSegment/reusableOutputSegment
- FFM detects confined arena accessed from wrong thread, throws WrongThreadException

Fix: Arena.ofShared() is thread-safe for MemorySegment access across threads. FFM's confinement check no longer applies—multiple threads can safely copy into the same segments as long as access patterns are correct (no concurrent writes to same segment offset, which is guaranteed here: encoder writes to segments sequentially).