### PR TITLE
feat(#50): IPv6 public-IP discovery and tri-state IP-family config

### DIFF
--- a/core/pom.xml
+++ b/core/pom.xml
@@ -44,26 +44,6 @@
       <scope>provided</scope>
     </dependency>
 
-    <!-- JAX-RS 2.1 client API — provided at runtime by Liberty's jaxrsClient feature -->
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <!-- JAXB API — satisfies the compile-time java.xml.bind transitive requirement from javax.ws.rs-api -->
-    <dependency>
-      <groupId>javax.xml.bind</groupId>
-      <artifactId>jaxb-api</artifactId>
-      <scope>provided</scope>
-    </dependency>
-
-    <!-- Apache CXF: JAX-RS client implementation for tests -->
-    <dependency>
-      <groupId>org.apache.cxf</groupId>
-      <artifactId>cxf-rt-rs-client</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 
   <build>

--- a/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
+++ b/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
@@ -17,9 +17,11 @@ import de.bmarwell.proximo.pitido.services.api.PublicIpv6DiscoveryService;
 import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.Inet4Address;
+import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
 import java.net.SocketException;
+import java.net.UnknownHostException;
 import java.util.Collections;
 import java.util.Optional;
 import javax.enterprise.context.ApplicationScoped;
@@ -36,10 +38,11 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
  *       as-is without any network call (backward-compatible with pre-IPv6 deployments).</li>
  *   <li>{@code SIP_PUBLIC_IPV6} / {@code sip.public.ipv6} — tri-state IPv6 control:
  *       <ul>
- *         <li>{@code "disabled"} — IPv6 is skipped entirely; proceed to IPv4.</li>
- *         <li>{@code "auto"} (default) — query {@link PublicIpv6DiscoveryService}; use the result
+ *         <li>{@code "disabled"} (default) — IPv6 is skipped entirely; proceed to IPv4.</li>
+ *         <li>{@code "auto"} — query {@link PublicIpv6DiscoveryService}; use the result
  *             if successful.</li>
- *         <li>any other value — used as a literal IPv6 address without any network call.</li>
+ *         <li>any other value — treated as a literal IPv6 address (brackets optional);
+ *             validated and used without any network call.</li>
  *       </ul>
  *       Primarily useful on DS-Lite connections where no public IPv4 address is available.
  *       Note: callers building SIP URIs must bracket the returned address
@@ -49,7 +52,8 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
  *         <li>{@code "disabled"} — IPv4 is skipped entirely; fall through to local detection.</li>
  *         <li>{@code "auto"} (default) — query {@link PublicIpv4DiscoveryService}; use the result
  *             if successful.</li>
- *         <li>any other value — used as a literal IPv4 address without any network call.</li>
+ *         <li>any other value — treated as a literal IPv4 address; validated and used
+ *             without any network call.</li>
  *       </ul></li>
  *   <li>Outbound interface IP detected via a connected {@link DatagramSocket} pointed at the
  *       configured SIP registrar — reliable in Docker and Podman environments because it consults
@@ -134,8 +138,7 @@ public class LocalSipHostProvider {
         }
 
         if (!MODE_AUTO.equalsIgnoreCase(this.ipv6Mode)) {
-            LOGGER.log(System.Logger.Level.INFO, "SIP Contact address (sip.public.ipv6 literal): {0}", this.ipv6Mode);
-            return Optional.of(this.ipv6Mode);
+            return parseIpv6Literal(this.ipv6Mode);
         }
 
         Optional<String> discovered = this.publicIpv6DiscoveryService.discover().map(InetAddress::getHostAddress);
@@ -156,8 +159,7 @@ public class LocalSipHostProvider {
         }
 
         if (!MODE_AUTO.equalsIgnoreCase(this.ipv4Mode)) {
-            LOGGER.log(System.Logger.Level.INFO, "SIP Contact address (sip.public.ipv4 literal): {0}", this.ipv4Mode);
-            return Optional.of(this.ipv4Mode);
+            return parseIpv4Literal(this.ipv4Mode);
         }
 
         if (!this.registrationEnabled) {
@@ -176,6 +178,82 @@ public class LocalSipHostProvider {
         }
 
         return discovered;
+    }
+
+    /**
+     * Validates and normalises a user-supplied IPv6 literal.
+     *
+     * <p>Brackets ({@code [2001:db8::1]}) are stripped before parsing so operators may supply
+     * the address in either bare or bracketed form.
+     * The bare address is returned so that {@code buildContactAddress()} can apply its own
+     * bracketing consistently.
+     * Non-IPv6 values are rejected with a WARNING log and an empty result.
+     */
+    private Optional<String> parseIpv6Literal(String raw) {
+        String bare = raw.strip();
+
+        if (bare.startsWith("[") && bare.endsWith("]")) {
+            bare = bare.substring(1, bare.length() - 1);
+        }
+
+        try {
+            InetAddress addr = InetAddress.getByName(bare);
+
+            if (!(addr instanceof Inet6Address)) {
+                LOGGER.log(
+                        System.Logger.Level.WARNING,
+                        "sip.public.ipv6 / SIP_PUBLIC_IPV6 is set to a non-IPv6 value: [{0}]; ignoring.",
+                        raw);
+
+                return Optional.empty();
+            }
+
+            String literal = addr.getHostAddress();
+            LOGGER.log(System.Logger.Level.INFO, "SIP Contact address (sip.public.ipv6 literal): {0}", literal);
+
+            return Optional.of(literal);
+        } catch (UnknownHostException unknownHostException) {
+            LOGGER.log(
+                    System.Logger.Level.WARNING,
+                    "sip.public.ipv6 / SIP_PUBLIC_IPV6 is not a valid address: [{0}]; ignoring.",
+                    raw);
+
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Validates a user-supplied IPv4 literal.
+     *
+     * <p>Whitespace is stripped before parsing.
+     * Non-IPv4 values (hostnames, IPv6 addresses, malformed strings) are rejected with a WARNING
+     * log and an empty result.
+     */
+    private Optional<String> parseIpv4Literal(String raw) {
+        try {
+            InetAddress addr = InetAddress.getByName(raw.strip());
+
+            if (!(addr instanceof Inet4Address)) {
+                LOGGER.log(
+                        System.Logger.Level.WARNING,
+                        "sip.public.ipv4 / SIP_PUBLIC_IPV4 is set to a non-IPv4 value: [{0}]; ignoring.",
+                        raw);
+
+                return Optional.empty();
+            }
+
+            String literal = addr.getHostAddress();
+            LOGGER.log(System.Logger.Level.INFO, "SIP Contact address (sip.public.ipv4 literal): {0}", literal);
+
+            return Optional.of(literal);
+        } catch (UnknownHostException unknownHostException) {
+            LOGGER.log(
+                    System.Logger.Level.WARNING,
+                    "sip.public.ipv4 / SIP_PUBLIC_IPV4 is not a valid address: [{0}]; ignoring.",
+                    raw);
+
+            return Optional.empty();
+        }
     }
 
     private String detectLocalAddress() {

--- a/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
+++ b/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
@@ -12,6 +12,7 @@
  */
 package de.bmarwell.proximo.pitido.core.sip;
 
+import de.bmarwell.proximo.pitido.services.api.PublicIpv6DiscoveryService;
 import java.io.IOException;
 import java.net.DatagramSocket;
 import java.net.Inet4Address;
@@ -31,17 +32,30 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
  *
  * <ol>
  *   <li>{@code SIP_PUBLIC_HOST} / {@code sip.public.host} — explicit operator override; used
- *       as-is without any network call.</li>
- *   <li>Public IP auto-detected via {@link PublicIpDiscoveryService} — used when
- *       {@code SIP_REGISTRATION_ENABLED=true} and {@code SIP_PUBLIC_HOST} is absent.
- *       Behind NAT (home router, Docker host), a local IP in the Contact header is unreachable
- *       from the registrar, so a public IP is necessary.</li>
+ *       as-is without any network call (backward-compatible with pre-IPv6 deployments).</li>
+ *   <li>{@code SIP_PUBLIC_IPV6} / {@code sip.public.ipv6} — tri-state IPv6 control:
+ *       <ul>
+ *         <li>{@code "disabled"} — IPv6 is skipped entirely; proceed to IPv4.</li>
+ *         <li>{@code "auto"} (default) — query {@link PublicIpv6DiscoveryService}; use the result
+ *             if successful.</li>
+ *         <li>any other value — used as a literal IPv6 address without any network call.</li>
+ *       </ul>
+ *       Primarily useful on DS-Lite connections where no public IPv4 address is available.
+ *       Note: callers building SIP URIs must bracket the returned address
+ *       ({@code sip:user@[2001:db8::1]}) per RFC 3261 §19.1.1.</li>
+ *   <li>{@code SIP_PUBLIC_IPV4} / {@code sip.public.ipv4} — tri-state IPv4 control:
+ *       <ul>
+ *         <li>{@code "disabled"} — IPv4 is skipped entirely; fall through to local detection.</li>
+ *         <li>{@code "auto"} (default) — query {@link PublicIpDiscoveryService}; use the result
+ *             if successful.</li>
+ *         <li>any other value — used as a literal IPv4 address without any network call.</li>
+ *       </ul></li>
  *   <li>Outbound interface IP detected via a connected {@link DatagramSocket} pointed at the
  *       configured SIP registrar — reliable in Docker and Podman environments because it consults
  *       the OS routing table rather than enumerating network interfaces.
  *       No data is sent; the socket is used only for routing-table lookup.</li>
  *   <li>First non-loopback, non-link-local IPv4 address on any active network interface —
- *       final fallback used when registration is disabled or all other detection methods fail.</li>
+ *       final fallback used when all other detection methods fail.</li>
  * </ol>
  */
 @ApplicationScoped
@@ -50,10 +64,20 @@ public class LocalSipHostProvider {
     private static final System.Logger LOGGER = System.getLogger(LocalSipHostProvider.class.getName());
 
     private static final String FALLBACK_ADDRESS = "127.0.0.1";
+    private static final String MODE_DISABLED = "disabled";
+    private static final String MODE_AUTO = "auto";
 
     @Inject
     @ConfigProperty(name = "sip.public.host")
     Optional<String> configuredHost;
+
+    @Inject
+    @ConfigProperty(name = "sip.public.ipv4", defaultValue = MODE_AUTO)
+    String ipv4Mode;
+
+    @Inject
+    @ConfigProperty(name = "sip.public.ipv6", defaultValue = MODE_DISABLED)
+    String ipv6Mode;
 
     @Inject
     @ConfigProperty(name = "sip.registrar")
@@ -65,6 +89,9 @@ public class LocalSipHostProvider {
 
     @Inject
     PublicIpDiscoveryService publicIpDiscoveryService;
+
+    @Inject
+    PublicIpv6DiscoveryService publicIpv6DiscoveryService;
 
     /** CDI no-args constructor. */
     public LocalSipHostProvider() {}
@@ -78,32 +105,76 @@ public class LocalSipHostProvider {
             return host;
         }
 
-        if (!this.registrationEnabled) {
-            String host = detectLocalAddress();
-            LOGGER.log(System.Logger.Level.INFO, "Local SIP host (auto-detected, registration disabled): {0}", host);
+        Optional<String> ipv6 = resolveIpv6();
 
-            return host;
+        if (ipv6.isPresent()) {
+            return ipv6.get();
         }
 
-        Optional<String> publicIp = this.publicIpDiscoveryService.discover();
+        Optional<String> ipv4 = resolveIpv4();
 
-        if (publicIp.isPresent()) {
-            LOGGER.log(
-                    System.Logger.Level.INFO,
-                    "SIP Contact address (public IP via PublicIpDiscoveryService): {0}",
-                    publicIp.get());
-
-            return publicIp.get();
+        if (ipv4.isPresent()) {
+            return ipv4.get();
         }
 
         LOGGER.log(
                 System.Logger.Level.WARNING,
-                "All public IP discovery services unreachable; falling back to local IP for Contact header."
+                "All public IP discovery services unreachable or disabled; falling back to local IP for Contact header."
                         + " Incoming calls may fail if this host is behind NAT.");
         String host = detectLocalAddress();
         LOGGER.log(System.Logger.Level.INFO, "Local SIP host (auto-detected fallback): {0}", host);
 
         return host;
+    }
+
+    private Optional<String> resolveIpv6() {
+        if (MODE_DISABLED.equalsIgnoreCase(this.ipv6Mode)) {
+            return Optional.empty();
+        }
+
+        if (!MODE_AUTO.equalsIgnoreCase(this.ipv6Mode)) {
+            LOGGER.log(System.Logger.Level.INFO, "SIP Contact address (sip.public.ipv6 literal): {0}", this.ipv6Mode);
+            return Optional.of(this.ipv6Mode);
+        }
+
+        Optional<String> discovered = this.publicIpv6DiscoveryService.discover();
+
+        if (discovered.isPresent()) {
+            LOGGER.log(
+                    System.Logger.Level.INFO,
+                    "SIP Contact address (public IPv6 via PublicIpv6DiscoveryService): {0}",
+                    discovered.get());
+        }
+
+        return discovered;
+    }
+
+    private Optional<String> resolveIpv4() {
+        if (MODE_DISABLED.equalsIgnoreCase(this.ipv4Mode)) {
+            return Optional.empty();
+        }
+
+        if (!MODE_AUTO.equalsIgnoreCase(this.ipv4Mode)) {
+            LOGGER.log(System.Logger.Level.INFO, "SIP Contact address (sip.public.ipv4 literal): {0}", this.ipv4Mode);
+            return Optional.of(this.ipv4Mode);
+        }
+
+        if (!this.registrationEnabled) {
+            String host = detectLocalAddress();
+            LOGGER.log(System.Logger.Level.INFO, "Local SIP host (auto-detected, registration disabled): {0}", host);
+            return Optional.of(host);
+        }
+
+        Optional<String> discovered = this.publicIpDiscoveryService.discover();
+
+        if (discovered.isPresent()) {
+            LOGGER.log(
+                    System.Logger.Level.INFO,
+                    "SIP Contact address (public IPv4 via PublicIpDiscoveryService): {0}",
+                    discovered.get());
+        }
+
+        return discovered;
     }
 
     private String detectLocalAddress() {

--- a/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
+++ b/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
@@ -12,6 +12,7 @@
  */
 package de.bmarwell.proximo.pitido.core.sip;
 
+import de.bmarwell.proximo.pitido.services.api.PublicIpv4DiscoveryService;
 import de.bmarwell.proximo.pitido.services.api.PublicIpv6DiscoveryService;
 import java.io.IOException;
 import java.net.DatagramSocket;
@@ -46,7 +47,7 @@ import org.eclipse.microprofile.config.inject.ConfigProperty;
  *   <li>{@code SIP_PUBLIC_IPV4} / {@code sip.public.ipv4} — tri-state IPv4 control:
  *       <ul>
  *         <li>{@code "disabled"} — IPv4 is skipped entirely; fall through to local detection.</li>
- *         <li>{@code "auto"} (default) — query {@link PublicIpDiscoveryService}; use the result
+ *         <li>{@code "auto"} (default) — query {@link PublicIpv4DiscoveryService}; use the result
  *             if successful.</li>
  *         <li>any other value — used as a literal IPv4 address without any network call.</li>
  *       </ul></li>
@@ -88,7 +89,7 @@ public class LocalSipHostProvider {
     boolean registrationEnabled;
 
     @Inject
-    PublicIpDiscoveryService publicIpDiscoveryService;
+    PublicIpv4DiscoveryService publicIpv4DiscoveryService;
 
     @Inject
     PublicIpv6DiscoveryService publicIpv6DiscoveryService;
@@ -165,12 +166,12 @@ public class LocalSipHostProvider {
             return Optional.of(host);
         }
 
-        Optional<String> discovered = this.publicIpDiscoveryService.discover();
+        Optional<String> discovered = this.publicIpv4DiscoveryService.discover();
 
         if (discovered.isPresent()) {
             LOGGER.log(
                     System.Logger.Level.INFO,
-                    "SIP Contact address (public IPv4 via PublicIpDiscoveryService): {0}",
+                    "SIP Contact address (public IPv4 via PublicIpv4DiscoveryService): {0}",
                     discovered.get());
         }
 

--- a/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
+++ b/core/src/main/java/de/bmarwell/proximo/pitido/core/sip/LocalSipHostProvider.java
@@ -138,7 +138,7 @@ public class LocalSipHostProvider {
             return Optional.of(this.ipv6Mode);
         }
 
-        Optional<String> discovered = this.publicIpv6DiscoveryService.discover();
+        Optional<String> discovered = this.publicIpv6DiscoveryService.discover().map(InetAddress::getHostAddress);
 
         if (discovered.isPresent()) {
             LOGGER.log(
@@ -166,7 +166,7 @@ public class LocalSipHostProvider {
             return Optional.of(host);
         }
 
-        Optional<String> discovered = this.publicIpv4DiscoveryService.discover();
+        Optional<String> discovered = this.publicIpv4DiscoveryService.discover().map(InetAddress::getHostAddress);
 
         if (discovered.isPresent()) {
             LOGGER.log(

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -16,6 +16,7 @@
 module de.bmarwell.proximo.pitido.core {
     // Internal project modules
     requires transitive de.bmarwell.proximo.pitido.spi;
+    requires de.bmarwell.proximo.pitido.services.api;
 
     // CDI 2.0 (javax namespace) — provided by the Liberty container at runtime.
     // Transitive because @ApplicationScoped is a runtime-visible annotation on exported types;

--- a/core/src/main/java/module-info.java
+++ b/core/src/main/java/module-info.java
@@ -28,11 +28,6 @@ module de.bmarwell.proximo.pitido.core {
     // JDK platform modules
     requires java.naming; // javax.naming.* — JNDI SRV DNS lookup (package-private use only)
 
-    // JAX-RS 2.1 client API — provided at runtime by Liberty's jaxrsClient feature.
-    // javax.ws.rs-api declares "requires transitive java.xml.bind"; jaxb-api on the
-    // module path satisfies that at compile time; Liberty's jaxb feature covers runtime.
-    requires java.ws.rs;
-
     // MicroProfile Config — provided by Liberty; annotation-only use (@ConfigProperty)
     requires static microprofile.config.api;
 

--- a/pom.xml
+++ b/pom.xml
@@ -105,6 +105,18 @@
         <scope>provided</scope>
       </dependency>
 
+      <!-- Internal: services -->
+      <dependency>
+        <groupId>de.bmarwell.proximo.pitido</groupId>
+        <artifactId>proximo-pitido-services-api</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+      <dependency>
+        <groupId>de.bmarwell.proximo.pitido</groupId>
+        <artifactId>proximo-pitido-services-ip</artifactId>
+        <version>1.0.0-SNAPSHOT</version>
+      </dependency>
+
       <!-- Apache CXF JAX-RS client — test-time ClientBuilder SPI implementation -->
       <dependency>
         <groupId>org.apache.cxf</groupId>
@@ -415,6 +427,7 @@
     <subproject>spi</subproject>
     <subproject>codecs</subproject>
     <subproject>core</subproject>
+    <subproject>services</subproject>
     <subproject>test-support</subproject>
     <subproject>languages</subproject>
     <subproject>war</subproject>

--- a/services/api/pom.xml
+++ b/services/api/pom.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+  <modelVersion>4.1.0</modelVersion>
+
+  <parent>
+    <groupId>de.bmarwell.proximo.pitido</groupId>
+    <artifactId>proximo-pitido-services</artifactId>
+  </parent>
+
+  <artifactId>proximo-pitido-services-api</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <name>Proximo Pitido :: Services :: API</name>
+
+  <description>Pure-interface API for cross-cutting services (IP discovery, …).
+    No implementation classes; no container dependencies.
+    Consumers compile against this module and receive implementations at runtime via the
+    proximo-pitido-services-ip (or other) runtime dependency.</description>
+</project>

--- a/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpDiscoveryService.java
+++ b/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpDiscoveryService.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.services.api;
+
+import java.net.InetAddress;
+import java.util.Optional;
+
+/**
+ * Sealed root contract for public-IP discovery services.
+ *
+ * <p>The two permitted sub-interfaces — {@link PublicIpv4DiscoveryService} and
+ * {@link PublicIpv6DiscoveryService} — specialise this contract for each address family.
+ * Callers that need to handle both families can use a switch expression over the
+ * sub-interface type.
+ *
+ * <p>Implementations query remote IP-echo services and cache the result.
+ * When all services are unreachable, {@link Optional#empty()} is returned.
+ */
+public sealed interface PublicIpDiscoveryService permits PublicIpv4DiscoveryService, PublicIpv6DiscoveryService {
+
+    /**
+     * Returns the public IP address of this host.
+     *
+     * <p>The concrete type of the returned {@link InetAddress} matches the implementing
+     * sub-interface:
+     * {@link java.net.Inet4Address} for {@link PublicIpv4DiscoveryService} and
+     * {@link java.net.Inet6Address} for {@link PublicIpv6DiscoveryService}.
+     *
+     * @return the discovered address, or {@link Optional#empty()} when all services fail
+     */
+    Optional<InetAddress> discover();
+}

--- a/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpv4DiscoveryService.java
+++ b/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpv4DiscoveryService.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.services.api;
+
+import java.util.Optional;
+
+/**
+ * Discovers the public IPv4 address of this host.
+ *
+ * <p>Implementations query remote IP-echo services and cache the result.
+ * When all services are unreachable, {@link Optional#empty()} is returned.
+ *
+ * <p>This interface exists so that the {@code core} module can depend on the contract
+ * without coupling to any specific implementation.
+ * The implementation is provided at runtime by {@code proximo-pitido-services-ip}.
+ */
+public interface PublicIpv4DiscoveryService {
+
+    /**
+     * Returns the public IPv4 address of this host.
+     *
+     * @return the discovered address, or {@link Optional#empty()} when all services fail
+     */
+    Optional<String> discover();
+}

--- a/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpv4DiscoveryService.java
+++ b/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpv4DiscoveryService.java
@@ -12,24 +12,29 @@
  */
 package de.bmarwell.proximo.pitido.services.api;
 
+import java.net.Inet4Address;
+import java.net.InetAddress;
 import java.util.Optional;
 
 /**
  * Discovers the public IPv4 address of this host.
  *
- * <p>Implementations query remote IP-echo services and cache the result.
+ * <p>Implementations query remote IPv4-only IP-echo services and cache the result.
  * When all services are unreachable, {@link Optional#empty()} is returned.
+ *
+ * <p>The returned {@link InetAddress} is always an {@link Inet4Address}.
  *
  * <p>This interface exists so that the {@code core} module can depend on the contract
  * without coupling to any specific implementation.
  * The implementation is provided at runtime by {@code proximo-pitido-services-ip}.
  */
-public interface PublicIpv4DiscoveryService {
+public non-sealed interface PublicIpv4DiscoveryService extends PublicIpDiscoveryService {
 
     /**
      * Returns the public IPv4 address of this host.
      *
-     * @return the discovered address, or {@link Optional#empty()} when all services fail
+     * @return the discovered {@link Inet4Address}, or {@link Optional#empty()} when all services fail
      */
-    Optional<String> discover();
+    @Override
+    Optional<InetAddress> discover();
 }

--- a/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpv6DiscoveryService.java
+++ b/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpv6DiscoveryService.java
@@ -12,6 +12,8 @@
  */
 package de.bmarwell.proximo.pitido.services.api;
 
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.util.Optional;
 
 /**
@@ -24,17 +26,17 @@ import java.util.Optional;
  * <p>When all services are unreachable (e.g. the host has no IPv6 connectivity),
  * {@link Optional#empty()} is returned and the caller falls back to IPv4.
  *
- * <p>Returned addresses are bare IPv6 literals without enclosing brackets,
- * e.g. {@code "2001:db8::1"}.
- * Callers that embed the address in a SIP URI must add brackets themselves
+ * <p>The returned {@link InetAddress} is always an {@link Inet6Address}.
+ * Callers that embed the address in a SIP URI must format it with square brackets
  * ({@code sip:user@[2001:db8::1]}) per RFC 3261 §19.1.1.
  */
-public interface PublicIpv6DiscoveryService {
+public non-sealed interface PublicIpv6DiscoveryService extends PublicIpDiscoveryService {
 
     /**
      * Returns the public IPv6 address of this host.
      *
-     * @return the discovered address without brackets, or {@link Optional#empty()} when all services fail
+     * @return the discovered {@link Inet6Address}, or {@link Optional#empty()} when all services fail
      */
-    Optional<String> discover();
+    @Override
+    Optional<InetAddress> discover();
 }

--- a/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpv6DiscoveryService.java
+++ b/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpv6DiscoveryService.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.services.api;
+
+import java.util.Optional;
+
+/**
+ * Discovers the public IPv6 address of this host.
+ *
+ * <p>Implementations query remote IPv6-only IP-echo services and cache the result.
+ * This is primarily useful on DS-Lite connections, where the host has no public IPv4 address
+ * and must advertise an IPv6 address in the SIP {@code Contact} header.
+ *
+ * <p>When all services are unreachable (e.g. the host has no IPv6 connectivity),
+ * {@link Optional#empty()} is returned and the caller falls back to IPv4.
+ *
+ * <p>Returned addresses are bare IPv6 literals without enclosing brackets,
+ * e.g. {@code "2001:db8::1"}.
+ * Callers that embed the address in a SIP URI must add brackets themselves
+ * ({@code sip:user@[2001:db8::1]}) per RFC 3261 §19.1.1.
+ */
+public interface PublicIpv6DiscoveryService {
+
+    /**
+     * Returns the public IPv6 address of this host.
+     *
+     * @return the discovered address without brackets, or {@link Optional#empty()} when all services fail
+     */
+    Optional<String> discover();
+}

--- a/services/api/src/main/java/module-info.java
+++ b/services/api/src/main/java/module-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+
+/**
+ * Public API interfaces for cross-cutting services.
+ *
+ * <p>This module defines service contracts with no implementation and no container dependency.
+ * Compile against this module; receive implementations at runtime from
+ * {@code de.bmarwell.proximo.pitido.services.ip} (or another provider on the classpath).
+ */
+module de.bmarwell.proximo.pitido.services.api {
+    exports de.bmarwell.proximo.pitido.services.api;
+}

--- a/services/ip/pom.xml
+++ b/services/ip/pom.xml
@@ -4,24 +4,26 @@
 
   <parent>
     <groupId>de.bmarwell.proximo.pitido</groupId>
-    <artifactId>proximo-pitido</artifactId>
+    <artifactId>proximo-pitido-services</artifactId>
   </parent>
 
-  <artifactId>proximo-pitido-core</artifactId>
+  <artifactId>proximo-pitido-services-ip</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
 
-  <name>Proximo Pitido :: Core</name>
+  <name>Proximo Pitido :: Services :: IP Discovery</name>
+
+  <description>
+    Implementations of IP-discovery service interfaces (IPv4 and IPv6).
+    Declares CDI beans; must be on the classpath of the WAR at runtime.
+    Consumers declare proximo-pitido-services-api as a compile dependency and this
+    module as a runtime dependency.
+  </description>
 
   <dependencies>
     <dependency>
       <groupId>de.bmarwell.proximo.pitido</groupId>
-      <artifactId>proximo-pitido-spi</artifactId>
-      <version>1.0.0-SNAPSHOT</version>
-      <scope>compile</scope>
-    </dependency>
-
-    <dependency>
-      <groupId>de.bmarwell.proximo.pitido</groupId>
       <artifactId>proximo-pitido-services-api</artifactId>
+      <version>1.0.0-SNAPSHOT</version>
     </dependency>
 
     <dependency>
@@ -32,15 +34,11 @@
     <dependency>
       <groupId>javax.inject</groupId>
       <artifactId>javax.inject</artifactId>
+      <scope>provided</scope>
     </dependency>
     <dependency>
       <groupId>jakarta.annotation</groupId>
       <artifactId>jakarta.annotation-api</artifactId>
-    </dependency>
-
-    <dependency>
-      <groupId>org.eclipse.microprofile.config</groupId>
-      <artifactId>microprofile-config-api</artifactId>
       <scope>provided</scope>
     </dependency>
 
@@ -102,5 +100,4 @@
       </plugin>
     </plugins>
   </build>
-
 </project>

--- a/services/ip/src/main/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv4DiscoveryServiceImpl.java
+++ b/services/ip/src/main/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv4DiscoveryServiceImpl.java
@@ -74,15 +74,15 @@ public class PublicIpv4DiscoveryServiceImpl implements PublicIpv4DiscoveryServic
             .readTimeout(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .build();
 
-    private final AtomicReference<String> cachedIp = new AtomicReference<>();
+    private final AtomicReference<InetAddress> cachedIp = new AtomicReference<>();
     private volatile Instant cacheExpiry = Instant.MIN;
 
     /** CDI no-args constructor. */
     public PublicIpv4DiscoveryServiceImpl() {}
 
     @Override
-    public Optional<String> discover() {
-        String cached = this.cachedIp.get();
+    public Optional<InetAddress> discover() {
+        InetAddress cached = this.cachedIp.get();
 
         if (cached != null && Instant.now().isBefore(this.cacheExpiry)) {
             return Optional.of(cached);
@@ -91,12 +91,12 @@ public class PublicIpv4DiscoveryServiceImpl implements PublicIpv4DiscoveryServic
         return queryDiscoveryServices();
     }
 
-    private Optional<String> queryDiscoveryServices() {
+    private Optional<InetAddress> queryDiscoveryServices() {
         Client client = this.clientFactory.get();
 
         try {
             for (URI url : DISCOVERY_URLS) {
-                Optional<String> ip = queryService(client, url);
+                Optional<InetAddress> ip = queryService(client, url);
 
                 if (ip.isPresent()) {
                     this.cachedIp.set(ip.get());
@@ -111,20 +111,26 @@ public class PublicIpv4DiscoveryServiceImpl implements PublicIpv4DiscoveryServic
         return Optional.empty();
     }
 
-    private Optional<String> queryService(Client client, URI url) {
+    private Optional<InetAddress> queryService(Client client, URI url) {
         try {
             String body = client.target(url)
                     .request(MediaType.TEXT_PLAIN_TYPE)
                     .get(String.class)
                     .strip();
 
-            if (!isValidPublicIpv4Address(body)) {
+            Optional<InetAddress> addr = parseIpv4Address(body);
+
+            if (addr.isEmpty()) {
                 LOGGER.log(System.Logger.Level.DEBUG, "Unexpected response from {0}: {1}", url, body);
                 return Optional.empty();
             }
 
-            LOGGER.log(System.Logger.Level.INFO, "Discovered public IPv4 address {0} via {1}", body, url);
-            return Optional.of(body);
+            LOGGER.log(
+                    System.Logger.Level.INFO,
+                    "Discovered public IPv4 address {0} via {1}",
+                    addr.get().getHostAddress(),
+                    url);
+            return addr;
         } catch (ProcessingException processingException) {
             LOGGER.log(
                     System.Logger.Level.DEBUG,
@@ -136,24 +142,32 @@ public class PublicIpv4DiscoveryServiceImpl implements PublicIpv4DiscoveryServic
     }
 
     /**
-     * Returns {@code true} only when {@code candidate} is a literal dotted-decimal IPv4 address.
+     * Parses {@code candidate} as a literal dotted-decimal IPv4 address.
      *
      * <p>Uses a round-trip check — {@link InetAddress#getHostAddress()} must equal the original
      * input — to reject DNS hostnames that {@link InetAddress#getByName(String)} would otherwise
      * silently resolve.
      * IPv4 addresses are at most 15 characters ({@code "255.255.255.255"});
      * any longer string is rejected immediately.
+     *
+     * @return the parsed {@link Inet4Address}, or {@link Optional#empty()} if {@code candidate}
+     *     is not a valid public IPv4 literal
      */
-    static boolean isValidPublicIpv4Address(String candidate) {
+    static Optional<InetAddress> parseIpv4Address(String candidate) {
         if (candidate == null || candidate.isBlank() || candidate.length() > 15) {
-            return false;
+            return Optional.empty();
         }
 
         try {
             InetAddress addr = InetAddress.getByName(candidate);
-            return addr instanceof Inet4Address && addr.getHostAddress().equals(candidate);
+
+            if (!(addr instanceof Inet4Address) || !addr.getHostAddress().equals(candidate)) {
+                return Optional.empty();
+            }
+
+            return Optional.of(addr);
         } catch (UnknownHostException unknownHostException) {
-            return false;
+            return Optional.empty();
         }
     }
 }

--- a/services/ip/src/main/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv4DiscoveryServiceImpl.java
+++ b/services/ip/src/main/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv4DiscoveryServiceImpl.java
@@ -10,8 +10,9 @@
  * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Licence for the specific language governing permissions and limitations under the Licence.
  */
-package de.bmarwell.proximo.pitido.core.sip;
+package de.bmarwell.proximo.pitido.services.ip;
 
+import de.bmarwell.proximo.pitido.services.api.PublicIpv4DiscoveryService;
 import java.net.Inet4Address;
 import java.net.InetAddress;
 import java.net.URI;
@@ -52,9 +53,9 @@ import javax.ws.rs.core.MediaType;
  * </ol>
  */
 @ApplicationScoped
-public class PublicIpDiscoveryService {
+public class PublicIpv4DiscoveryServiceImpl implements PublicIpv4DiscoveryService {
 
-    private static final System.Logger LOGGER = System.getLogger(PublicIpDiscoveryService.class.getName());
+    private static final System.Logger LOGGER = System.getLogger(PublicIpv4DiscoveryServiceImpl.class.getName());
 
     static final List<URI> DISCOVERY_URLS = List.of(
             URI.create("https://v4.ident.me"),
@@ -77,14 +78,9 @@ public class PublicIpDiscoveryService {
     private volatile Instant cacheExpiry = Instant.MIN;
 
     /** CDI no-args constructor. */
-    public PublicIpDiscoveryService() {}
+    public PublicIpv4DiscoveryServiceImpl() {}
 
-    /**
-     * Returns the public IPv4 address of this host, querying remote services if the cache is stale.
-     *
-     * @return the discovered IPv4 address, or {@link Optional#empty()} when all services are
-     *     unreachable
-     */
+    @Override
     public Optional<String> discover() {
         String cached = this.cachedIp.get();
 
@@ -127,12 +123,12 @@ public class PublicIpDiscoveryService {
                 return Optional.empty();
             }
 
-            LOGGER.log(System.Logger.Level.INFO, "Discovered public IP {0} via {1}", body, url);
+            LOGGER.log(System.Logger.Level.INFO, "Discovered public IPv4 address {0} via {1}", body, url);
             return Optional.of(body);
         } catch (ProcessingException processingException) {
             LOGGER.log(
                     System.Logger.Level.DEBUG,
-                    "Failed to query public IP from {0}: {1}",
+                    "Failed to query public IPv4 from {0}: {1}",
                     url,
                     processingException.getMessage());
             return Optional.empty();
@@ -145,6 +141,8 @@ public class PublicIpDiscoveryService {
      * <p>Uses a round-trip check — {@link InetAddress#getHostAddress()} must equal the original
      * input — to reject DNS hostnames that {@link InetAddress#getByName(String)} would otherwise
      * silently resolve.
+     * IPv4 addresses are at most 15 characters ({@code "255.255.255.255"});
+     * any longer string is rejected immediately.
      */
     static boolean isValidPublicIpv4Address(String candidate) {
         if (candidate == null || candidate.isBlank() || candidate.length() > 15) {

--- a/services/ip/src/main/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv6DiscoveryServiceImpl.java
+++ b/services/ip/src/main/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv6DiscoveryServiceImpl.java
@@ -50,11 +50,6 @@ import javax.ws.rs.core.MediaType;
  *   <li>{@code https://v6.ident.me} — plain text, IPv6 only</li>
  *   <li>{@code https://api6.ipify.org} — plain text, IPv6 only</li>
  * </ol>
- *
- * <p>Returned addresses are bare IPv6 literals without enclosing brackets,
- * e.g. {@code "2001:db8::1"}.
- * Callers embedding the address in a SIP URI must add brackets
- * ({@code sip:user@[2001:db8::1]}) per RFC 3261 §19.1.1.
  */
 @ApplicationScoped
 public class PublicIpv6DiscoveryServiceImpl implements PublicIpv6DiscoveryService {
@@ -76,15 +71,15 @@ public class PublicIpv6DiscoveryServiceImpl implements PublicIpv6DiscoveryServic
             .readTimeout(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
             .build();
 
-    private final AtomicReference<String> cachedIp = new AtomicReference<>();
+    private final AtomicReference<InetAddress> cachedIp = new AtomicReference<>();
     private volatile Instant cacheExpiry = Instant.MIN;
 
     /** CDI no-args constructor. */
     public PublicIpv6DiscoveryServiceImpl() {}
 
     @Override
-    public Optional<String> discover() {
-        String cached = this.cachedIp.get();
+    public Optional<InetAddress> discover() {
+        InetAddress cached = this.cachedIp.get();
 
         if (cached != null && Instant.now().isBefore(this.cacheExpiry)) {
             return Optional.of(cached);
@@ -93,12 +88,12 @@ public class PublicIpv6DiscoveryServiceImpl implements PublicIpv6DiscoveryServic
         return queryDiscoveryServices();
     }
 
-    private Optional<String> queryDiscoveryServices() {
+    private Optional<InetAddress> queryDiscoveryServices() {
         Client client = this.clientFactory.get();
 
         try {
             for (URI url : DISCOVERY_URLS) {
-                Optional<String> ip = queryService(client, url);
+                Optional<InetAddress> ip = queryService(client, url);
 
                 if (ip.isPresent()) {
                     this.cachedIp.set(ip.get());
@@ -113,20 +108,26 @@ public class PublicIpv6DiscoveryServiceImpl implements PublicIpv6DiscoveryServic
         return Optional.empty();
     }
 
-    private Optional<String> queryService(Client client, URI url) {
+    private Optional<InetAddress> queryService(Client client, URI url) {
         try {
             String body = client.target(url)
                     .request(MediaType.TEXT_PLAIN_TYPE)
                     .get(String.class)
                     .strip();
 
-            if (!isValidPublicIpv6Address(body)) {
+            Optional<InetAddress> addr = parseIpv6Address(body);
+
+            if (addr.isEmpty()) {
                 LOGGER.log(System.Logger.Level.DEBUG, "Unexpected response from {0}: {1}", url, body);
                 return Optional.empty();
             }
 
-            LOGGER.log(System.Logger.Level.INFO, "Discovered public IPv6 address {0} via {1}", body, url);
-            return Optional.of(body);
+            LOGGER.log(
+                    System.Logger.Level.INFO,
+                    "Discovered public IPv6 address {0} via {1}",
+                    addr.get().getHostAddress(),
+                    url);
+            return addr;
         } catch (ProcessingException processingException) {
             LOGGER.log(
                     System.Logger.Level.DEBUG,
@@ -138,7 +139,7 @@ public class PublicIpv6DiscoveryServiceImpl implements PublicIpv6DiscoveryServic
     }
 
     /**
-     * Returns {@code true} only when {@code candidate} is a bare literal IPv6 address.
+     * Parses {@code candidate} as a bare literal IPv6 address.
      *
      * <p>The check uses the presence of {@code ':'} as the IPv6 discriminator, then attempts to
      * parse the address with {@link InetAddress#getByName(String)}.
@@ -147,33 +148,40 @@ public class PublicIpv6DiscoveryServiceImpl implements PublicIpv6DiscoveryServic
      * cause the input to fail an equality comparison against the normalised output.
      * IPv4-mapped addresses ({@code ::ffff:1.2.3.4}) are rejected because they embed an IPv4 address
      * and would be misleading in an IPv6-only context.
+     *
+     * @return the parsed {@link Inet6Address}, or {@link Optional#empty()} if {@code candidate}
+     *     is not a valid public IPv6 literal
      */
-    static boolean isValidPublicIpv6Address(String candidate) {
+    static Optional<InetAddress> parseIpv6Address(String candidate) {
         if (candidate == null || candidate.isBlank()) {
-            return false;
+            return Optional.empty();
         }
 
         // Reject any bracketed form — services should return bare addresses
         if (candidate.startsWith("[") || candidate.endsWith("]")) {
-            return false;
+            return Optional.empty();
         }
 
         // All IPv6 addresses contain ':'; reject IPv4 addresses and hostnames early
         if (!candidate.contains(":")) {
-            return false;
+            return Optional.empty();
         }
 
         try {
             InetAddress addr = InetAddress.getByName(candidate);
 
             if (!(addr instanceof Inet6Address inet6)) {
-                return false;
+                return Optional.empty();
             }
 
             // Reject IPv4-mapped addresses
-            return !inet6.isIPv4CompatibleAddress();
+            if (inet6.isIPv4CompatibleAddress()) {
+                return Optional.empty();
+            }
+
+            return Optional.of(addr);
         } catch (UnknownHostException unknownHostException) {
-            return false;
+            return Optional.empty();
         }
     }
 }

--- a/services/ip/src/main/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv6DiscoveryServiceImpl.java
+++ b/services/ip/src/main/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv6DiscoveryServiceImpl.java
@@ -174,8 +174,9 @@ public class PublicIpv6DiscoveryServiceImpl implements PublicIpv6DiscoveryServic
                 return Optional.empty();
             }
 
-            // Reject IPv4-mapped addresses
-            if (inet6.isIPv4CompatibleAddress()) {
+            // Reject IPv4-compatible (::w.x.y.z) and IPv4-mapped (::ffff:w.x.y.z) addresses.
+            // isIPv4CompatibleAddress() only covers the former; inspect raw bytes for both.
+            if (isIpv4EmbeddedAddress(inet6)) {
                 return Optional.empty();
             }
 
@@ -183,5 +184,28 @@ public class PublicIpv6DiscoveryServiceImpl implements PublicIpv6DiscoveryServic
         } catch (UnknownHostException unknownHostException) {
             return Optional.empty();
         }
+    }
+
+    /**
+     * Returns {@code true} when {@code addr} is an IPv4-compatible ({@code ::w.x.y.z}) or
+     * IPv4-mapped ({@code ::ffff:w.x.y.z}) address.
+     *
+     * <p>{@link Inet6Address#isIPv4CompatibleAddress()} only detects the deprecated
+     * IPv4-compatible form; it does not detect the IPv4-mapped form.
+     * A raw byte check is therefore used to cover both cases.
+     */
+    private static boolean isIpv4EmbeddedAddress(Inet6Address addr) {
+        byte[] bytes = addr.getAddress();
+
+        // First 10 bytes must be zero for both forms
+        for (int byteIndex = 0; byteIndex < 10; byteIndex++) {
+            if (bytes[byteIndex] != 0) {
+                return false;
+            }
+        }
+
+        // IPv4-compatible: bytes 10–11 are 0x00 0x00
+        // IPv4-mapped:     bytes 10–11 are 0xFF 0xFF
+        return (bytes[10] == 0 && bytes[11] == 0) || (bytes[10] == (byte) 0xFF && bytes[11] == (byte) 0xFF);
     }
 }

--- a/services/ip/src/main/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv6DiscoveryServiceImpl.java
+++ b/services/ip/src/main/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv6DiscoveryServiceImpl.java
@@ -1,0 +1,179 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.services.ip;
+
+import de.bmarwell.proximo.pitido.services.api.PublicIpv6DiscoveryService;
+import java.net.Inet6Address;
+import java.net.InetAddress;
+import java.net.URI;
+import java.net.UnknownHostException;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Supplier;
+import javax.enterprise.context.ApplicationScoped;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.ClientBuilder;
+import javax.ws.rs.core.MediaType;
+
+/**
+ * Discovers the public IPv6 address of this host by querying IPv6-only plain-text IP-echo services.
+ *
+ * <p>Services are tried in order; the first successful, valid response is used.
+ * The result is cached for {@value #CACHE_HOURS} hour so that repeated calls during a registration
+ * cycle do not generate unnecessary HTTP traffic.
+ *
+ * <p>A fresh JAX-RS {@link Client} is created for each {@link #discover()} invocation and closed
+ * immediately afterwards.
+ * Each HTTP request times out after {@value #REQUEST_TIMEOUT_SECONDS} seconds.
+ * A failed request is logged at DEBUG level and the next service is tried.
+ * When all services fail (e.g. the host has no IPv6 connectivity),
+ * {@link Optional#empty()} is returned; the caller is responsible for falling back to IPv4.
+ *
+ * <h2>Services queried (in order)</h2>
+ *
+ * <ol>
+ *   <li>{@code https://v6.ident.me} — plain text, IPv6 only</li>
+ *   <li>{@code https://api6.ipify.org} — plain text, IPv6 only</li>
+ * </ol>
+ *
+ * <p>Returned addresses are bare IPv6 literals without enclosing brackets,
+ * e.g. {@code "2001:db8::1"}.
+ * Callers embedding the address in a SIP URI must add brackets
+ * ({@code sip:user@[2001:db8::1]}) per RFC 3261 §19.1.1.
+ */
+@ApplicationScoped
+public class PublicIpv6DiscoveryServiceImpl implements PublicIpv6DiscoveryService {
+
+    private static final System.Logger LOGGER = System.getLogger(PublicIpv6DiscoveryServiceImpl.class.getName());
+
+    static final List<URI> DISCOVERY_URLS =
+            List.of(URI.create("https://v6.ident.me"), URI.create("https://api6.ipify.org"));
+
+    private static final int CACHE_HOURS = 1;
+    private static final long REQUEST_TIMEOUT_SECONDS = 2L;
+
+    /**
+     * Factory used to create a short-lived JAX-RS {@link Client} per discovery invocation.
+     * Package-private so tests can substitute a supplier that returns a mock client.
+     */
+    Supplier<Client> clientFactory = () -> ClientBuilder.newBuilder()
+            .connectTimeout(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .readTimeout(REQUEST_TIMEOUT_SECONDS, TimeUnit.SECONDS)
+            .build();
+
+    private final AtomicReference<String> cachedIp = new AtomicReference<>();
+    private volatile Instant cacheExpiry = Instant.MIN;
+
+    /** CDI no-args constructor. */
+    public PublicIpv6DiscoveryServiceImpl() {}
+
+    @Override
+    public Optional<String> discover() {
+        String cached = this.cachedIp.get();
+
+        if (cached != null && Instant.now().isBefore(this.cacheExpiry)) {
+            return Optional.of(cached);
+        }
+
+        return queryDiscoveryServices();
+    }
+
+    private Optional<String> queryDiscoveryServices() {
+        Client client = this.clientFactory.get();
+
+        try {
+            for (URI url : DISCOVERY_URLS) {
+                Optional<String> ip = queryService(client, url);
+
+                if (ip.isPresent()) {
+                    this.cachedIp.set(ip.get());
+                    this.cacheExpiry = Instant.now().plus(Duration.ofHours(CACHE_HOURS));
+                    return ip;
+                }
+            }
+        } finally {
+            client.close();
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<String> queryService(Client client, URI url) {
+        try {
+            String body = client.target(url)
+                    .request(MediaType.TEXT_PLAIN_TYPE)
+                    .get(String.class)
+                    .strip();
+
+            if (!isValidPublicIpv6Address(body)) {
+                LOGGER.log(System.Logger.Level.DEBUG, "Unexpected response from {0}: {1}", url, body);
+                return Optional.empty();
+            }
+
+            LOGGER.log(System.Logger.Level.INFO, "Discovered public IPv6 address {0} via {1}", body, url);
+            return Optional.of(body);
+        } catch (ProcessingException processingException) {
+            LOGGER.log(
+                    System.Logger.Level.DEBUG,
+                    "Failed to query public IPv6 from {0}: {1}",
+                    url,
+                    processingException.getMessage());
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * Returns {@code true} only when {@code candidate} is a bare literal IPv6 address.
+     *
+     * <p>The check uses the presence of {@code ':'} as the IPv6 discriminator, then attempts to
+     * parse the address with {@link InetAddress#getByName(String)}.
+     * This avoids the round-trip equality trap where JVM normalisation expands a compressed form
+     * such as {@code "2001:db8::1"} to {@code "2001:db8:0:0:0:0:0:1"}, which would otherwise
+     * cause the input to fail an equality comparison against the normalised output.
+     * IPv4-mapped addresses ({@code ::ffff:1.2.3.4}) are rejected because they embed an IPv4 address
+     * and would be misleading in an IPv6-only context.
+     */
+    static boolean isValidPublicIpv6Address(String candidate) {
+        if (candidate == null || candidate.isBlank()) {
+            return false;
+        }
+
+        // Reject any bracketed form — services should return bare addresses
+        if (candidate.startsWith("[") || candidate.endsWith("]")) {
+            return false;
+        }
+
+        // All IPv6 addresses contain ':'; reject IPv4 addresses and hostnames early
+        if (!candidate.contains(":")) {
+            return false;
+        }
+
+        try {
+            InetAddress addr = InetAddress.getByName(candidate);
+
+            if (!(addr instanceof Inet6Address inet6)) {
+                return false;
+            }
+
+            // Reject IPv4-mapped addresses
+            return !inet6.isIPv4CompatibleAddress();
+        } catch (UnknownHostException unknownHostException) {
+            return false;
+        }
+    }
+}

--- a/services/ip/src/main/java/module-info.java
+++ b/services/ip/src/main/java/module-info.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+
+/**
+ * IP-discovery service implementations for Próximo Pitido.
+ *
+ * <p>This module provides CDI beans that implement the interfaces declared in
+ * {@code de.bmarwell.proximo.pitido.services.api}.
+ * It must appear on the WAR's runtime classpath so that the CDI container
+ * can discover and inject the implementations.
+ */
+module de.bmarwell.proximo.pitido.services.ip {
+    requires de.bmarwell.proximo.pitido.services.api;
+
+    // CDI 2.0 — provided by Liberty at runtime
+    requires transitive jakarta.enterprise.cdi.api;
+    requires java.annotation;
+    requires javax.inject;
+
+    // JAX-RS 2.1 client — provided by Liberty's jaxrsClient feature
+    requires java.ws.rs;
+
+    // Open for CDI reflection (Liberty CDI runs in OSGi; unqualified opens required)
+    opens de.bmarwell.proximo.pitido.services.ip;
+}

--- a/services/ip/src/test/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv4DiscoveryServiceImplTest.java
+++ b/services/ip/src/test/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv4DiscoveryServiceImplTest.java
@@ -10,7 +10,7 @@
  * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the Licence for the specific language governing permissions and limitations under the Licence.
  */
-package de.bmarwell.proximo.pitido.core.sip;
+package de.bmarwell.proximo.pitido.services.ip;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
@@ -35,7 +35,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 @ExtendWith(MockitoExtension.class)
-class PublicIpDiscoveryServiceTest {
+class PublicIpv4DiscoveryServiceImplTest {
 
     @Mock
     Client client;
@@ -46,15 +46,15 @@ class PublicIpDiscoveryServiceTest {
     @Mock
     Invocation.Builder requestBuilder;
 
-    PublicIpDiscoveryService discoveryService;
+    PublicIpv4DiscoveryServiceImpl discoveryService;
 
     @BeforeEach
     void setUp() {
-        this.discoveryService = new PublicIpDiscoveryService();
+        this.discoveryService = new PublicIpv4DiscoveryServiceImpl();
         this.discoveryService.clientFactory = () -> this.client;
     }
 
-    /** Stubs the JAX-RS fluent chain for tests that actually invoke {@link PublicIpDiscoveryService#discover()}. */
+    /** Stubs the JAX-RS fluent chain for tests that actually invoke {@link PublicIpv4DiscoveryServiceImpl#discover()}. */
     private void wireClientChain() {
         when(this.client.target(any(URI.class))).thenReturn(this.webTarget);
         when(this.webTarget.request(any(MediaType.class))).thenReturn(this.requestBuilder);
@@ -72,7 +72,7 @@ class PublicIpDiscoveryServiceTest {
         // then
         assertTrue(result.isPresent());
         assertEquals("1.2.3.4", result.get());
-        verify(this.client, times(1)).target(PublicIpDiscoveryService.DISCOVERY_URLS.getFirst());
+        verify(this.client, times(1)).target(PublicIpv4DiscoveryServiceImpl.DISCOVERY_URLS.getFirst());
     }
 
     @Test
@@ -160,25 +160,25 @@ class PublicIpDiscoveryServiceTest {
         this.discoveryService.discover();
 
         // then
-        verify(this.client, never()).target(PublicIpDiscoveryService.DISCOVERY_URLS.get(1));
-        verify(this.client, never()).target(PublicIpDiscoveryService.DISCOVERY_URLS.get(2));
+        verify(this.client, never()).target(PublicIpv4DiscoveryServiceImpl.DISCOVERY_URLS.get(1));
+        verify(this.client, never()).target(PublicIpv4DiscoveryServiceImpl.DISCOVERY_URLS.get(2));
     }
 
     @Test
     void isValidPublicIpv4Address_rejectsIpv6Address() {
         // given / when / then
-        assertFalse(PublicIpDiscoveryService.isValidPublicIpv4Address("2001:db8::1"));
+        assertFalse(PublicIpv4DiscoveryServiceImpl.isValidPublicIpv4Address("2001:db8::1"));
     }
 
     @Test
     void isValidPublicIpv4Address_rejectsHostname() {
         // given / when / then
-        assertFalse(PublicIpDiscoveryService.isValidPublicIpv4Address("example.com"));
+        assertFalse(PublicIpv4DiscoveryServiceImpl.isValidPublicIpv4Address("example.com"));
     }
 
     @Test
     void isValidPublicIpv4Address_acceptsLiteralIpv4() {
         // given / when / then
-        assertTrue(PublicIpDiscoveryService.isValidPublicIpv4Address("203.0.113.1"));
+        assertTrue(PublicIpv4DiscoveryServiceImpl.isValidPublicIpv4Address("203.0.113.1"));
     }
 }

--- a/services/ip/src/test/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv4DiscoveryServiceImplTest.java
+++ b/services/ip/src/test/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv4DiscoveryServiceImplTest.java
@@ -21,6 +21,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.InetAddress;
 import java.net.URI;
 import java.util.Optional;
 import javax.ws.rs.ProcessingException;
@@ -67,11 +68,11 @@ class PublicIpv4DiscoveryServiceImplTest {
         when(this.requestBuilder.get(String.class)).thenReturn("1.2.3.4");
 
         // when
-        Optional<String> result = this.discoveryService.discover();
+        Optional<InetAddress> result = this.discoveryService.discover();
 
         // then
         assertTrue(result.isPresent());
-        assertEquals("1.2.3.4", result.get());
+        assertEquals("1.2.3.4", result.get().getHostAddress());
         verify(this.client, times(1)).target(PublicIpv4DiscoveryServiceImpl.DISCOVERY_URLS.getFirst());
     }
 
@@ -84,11 +85,11 @@ class PublicIpv4DiscoveryServiceImplTest {
                 .thenReturn("5.6.7.8");
 
         // when
-        Optional<String> result = this.discoveryService.discover();
+        Optional<InetAddress> result = this.discoveryService.discover();
 
         // then
         assertTrue(result.isPresent());
-        assertEquals("5.6.7.8", result.get());
+        assertEquals("5.6.7.8", result.get().getHostAddress());
     }
 
     @Test
@@ -98,7 +99,7 @@ class PublicIpv4DiscoveryServiceImplTest {
         when(this.requestBuilder.get(String.class)).thenThrow(new ProcessingException("no route to host"));
 
         // when
-        Optional<String> result = this.discoveryService.discover();
+        Optional<InetAddress> result = this.discoveryService.discover();
 
         // then
         assertFalse(result.isPresent());
@@ -113,11 +114,11 @@ class PublicIpv4DiscoveryServiceImplTest {
                 .thenReturn("9.10.11.12");
 
         // when
-        Optional<String> result = this.discoveryService.discover();
+        Optional<InetAddress> result = this.discoveryService.discover();
 
         // then
         assertTrue(result.isPresent());
-        assertEquals("9.10.11.12", result.get());
+        assertEquals("9.10.11.12", result.get().getHostAddress());
     }
 
     @Test
@@ -128,11 +129,11 @@ class PublicIpv4DiscoveryServiceImplTest {
         this.discoveryService.discover();
 
         // when
-        Optional<String> cached = this.discoveryService.discover();
+        Optional<InetAddress> cached = this.discoveryService.discover();
 
         // then
         assertTrue(cached.isPresent());
-        assertEquals("1.2.3.4", cached.get());
+        assertEquals("1.2.3.4", cached.get().getHostAddress());
         verify(this.client, times(1)).target(any(URI.class));
     }
 
@@ -143,11 +144,11 @@ class PublicIpv4DiscoveryServiceImplTest {
         when(this.requestBuilder.get(String.class)).thenReturn("203.0.113.1\n");
 
         // when
-        Optional<String> result = this.discoveryService.discover();
+        Optional<InetAddress> result = this.discoveryService.discover();
 
         // then
         assertTrue(result.isPresent());
-        assertEquals("203.0.113.1", result.get());
+        assertEquals("203.0.113.1", result.get().getHostAddress());
     }
 
     @Test
@@ -165,20 +166,23 @@ class PublicIpv4DiscoveryServiceImplTest {
     }
 
     @Test
-    void isValidPublicIpv4Address_rejectsIpv6Address() {
+    void parseIpv4Address_rejectsIpv6Address() {
         // given / when / then
-        assertFalse(PublicIpv4DiscoveryServiceImpl.isValidPublicIpv4Address("2001:db8::1"));
+        assertTrue(
+                PublicIpv4DiscoveryServiceImpl.parseIpv4Address("2001:db8::1").isEmpty());
     }
 
     @Test
-    void isValidPublicIpv4Address_rejectsHostname() {
+    void parseIpv4Address_rejectsHostname() {
         // given / when / then
-        assertFalse(PublicIpv4DiscoveryServiceImpl.isValidPublicIpv4Address("example.com"));
+        assertTrue(
+                PublicIpv4DiscoveryServiceImpl.parseIpv4Address("example.com").isEmpty());
     }
 
     @Test
-    void isValidPublicIpv4Address_acceptsLiteralIpv4() {
+    void parseIpv4Address_acceptsLiteralIpv4() {
         // given / when / then
-        assertTrue(PublicIpv4DiscoveryServiceImpl.isValidPublicIpv4Address("203.0.113.1"));
+        assertTrue(
+                PublicIpv4DiscoveryServiceImpl.parseIpv4Address("203.0.113.1").isPresent());
     }
 }

--- a/services/ip/src/test/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv6DiscoveryServiceImplTest.java
+++ b/services/ip/src/test/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv6DiscoveryServiceImplTest.java
@@ -12,8 +12,8 @@
  */
 package de.bmarwell.proximo.pitido.services.ip;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.never;
@@ -21,6 +21,8 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import java.net.Inet6Address;
+import java.net.InetAddress;
 import java.net.URI;
 import java.util.Optional;
 import javax.ws.rs.ProcessingException;
@@ -66,11 +68,11 @@ class PublicIpv6DiscoveryServiceImplTest {
         when(this.requestBuilder.get(String.class)).thenReturn("2001:db8::1");
 
         // when
-        Optional<String> result = this.discoveryService.discover();
+        Optional<InetAddress> result = this.discoveryService.discover();
 
         // then
         assertTrue(result.isPresent());
-        assertEquals("2001:db8::1", result.get());
+        assertInstanceOf(Inet6Address.class, result.get());
         verify(this.client, times(1)).target(PublicIpv6DiscoveryServiceImpl.DISCOVERY_URLS.getFirst());
     }
 
@@ -83,11 +85,11 @@ class PublicIpv6DiscoveryServiceImplTest {
                 .thenReturn("2001:db8::2");
 
         // when
-        Optional<String> result = this.discoveryService.discover();
+        Optional<InetAddress> result = this.discoveryService.discover();
 
         // then
         assertTrue(result.isPresent());
-        assertEquals("2001:db8::2", result.get());
+        assertInstanceOf(Inet6Address.class, result.get());
     }
 
     @Test
@@ -97,7 +99,7 @@ class PublicIpv6DiscoveryServiceImplTest {
         when(this.requestBuilder.get(String.class)).thenThrow(new ProcessingException("no route to host"));
 
         // when
-        Optional<String> result = this.discoveryService.discover();
+        Optional<InetAddress> result = this.discoveryService.discover();
 
         // then
         assertFalse(result.isPresent());
@@ -112,11 +114,11 @@ class PublicIpv6DiscoveryServiceImplTest {
                 .thenReturn("2001:db8::3");
 
         // when
-        Optional<String> result = this.discoveryService.discover();
+        Optional<InetAddress> result = this.discoveryService.discover();
 
         // then
         assertTrue(result.isPresent());
-        assertEquals("2001:db8::3", result.get());
+        assertInstanceOf(Inet6Address.class, result.get());
     }
 
     @Test
@@ -127,11 +129,11 @@ class PublicIpv6DiscoveryServiceImplTest {
         this.discoveryService.discover();
 
         // when
-        Optional<String> cached = this.discoveryService.discover();
+        Optional<InetAddress> cached = this.discoveryService.discover();
 
         // then
         assertTrue(cached.isPresent());
-        assertEquals("2001:db8::1", cached.get());
+        assertInstanceOf(Inet6Address.class, cached.get());
         verify(this.client, times(1)).target(any(URI.class));
     }
 
@@ -142,11 +144,11 @@ class PublicIpv6DiscoveryServiceImplTest {
         when(this.requestBuilder.get(String.class)).thenReturn("2001:db8::1\n");
 
         // when
-        Optional<String> result = this.discoveryService.discover();
+        Optional<InetAddress> result = this.discoveryService.discover();
 
         // then
         assertTrue(result.isPresent());
-        assertEquals("2001:db8::1", result.get());
+        assertInstanceOf(Inet6Address.class, result.get());
     }
 
     @Test
@@ -163,46 +165,50 @@ class PublicIpv6DiscoveryServiceImplTest {
     }
 
     @Test
-    void isValidPublicIpv6Address_rejectsIpv4Address() {
+    void parseIpv6Address_rejectsIpv4Address() {
         // given / when / then
-        assertFalse(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address("1.2.3.4"));
+        assertTrue(PublicIpv6DiscoveryServiceImpl.parseIpv6Address("1.2.3.4").isEmpty());
     }
 
     @Test
-    void isValidPublicIpv6Address_rejectsHostname() {
+    void parseIpv6Address_rejectsHostname() {
         // given / when / then
-        assertFalse(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address("example.com"));
+        assertTrue(
+                PublicIpv6DiscoveryServiceImpl.parseIpv6Address("example.com").isEmpty());
     }
 
     @Test
-    void isValidPublicIpv6Address_rejectsBracketedAddress() {
+    void parseIpv6Address_rejectsBracketedAddress() {
         // given / when / then
-        assertFalse(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address("[2001:db8::1]"));
+        assertTrue(
+                PublicIpv6DiscoveryServiceImpl.parseIpv6Address("[2001:db8::1]").isEmpty());
     }
 
     @Test
-    void isValidPublicIpv6Address_rejectsNull() {
+    void parseIpv6Address_rejectsNull() {
         // given / when / then
-        assertFalse(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address(null));
+        assertTrue(PublicIpv6DiscoveryServiceImpl.parseIpv6Address(null).isEmpty());
     }
 
     @Test
-    void isValidPublicIpv6Address_rejectsBlank() {
+    void parseIpv6Address_rejectsBlank() {
         // given / when / then
-        assertFalse(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address("  "));
+        assertTrue(PublicIpv6DiscoveryServiceImpl.parseIpv6Address("  ").isEmpty());
     }
 
     @Test
-    void isValidPublicIpv6Address_acceptsFullAddress() {
+    void parseIpv6Address_acceptsFullAddress() {
         // given / when / then
-        assertTrue(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address("2001:db8:0:0:0:0:0:1"));
+        assertTrue(PublicIpv6DiscoveryServiceImpl.parseIpv6Address("2001:db8:0:0:0:0:0:1")
+                .isPresent());
     }
 
     @Test
-    void isValidPublicIpv6Address_acceptsCompressedAddress() {
+    void parseIpv6Address_acceptsCompressedAddress() {
         // given / when / then
         // Both compressed ("2001:db8::1") and expanded ("2001:db8:0:0:0:0:0:1") forms are valid.
         // The validation does not require the input to survive a JVM normalisation round-trip.
-        assertTrue(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address("2001:db8::1"));
+        assertTrue(
+                PublicIpv6DiscoveryServiceImpl.parseIpv6Address("2001:db8::1").isPresent());
     }
 }

--- a/services/ip/src/test/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv6DiscoveryServiceImplTest.java
+++ b/services/ip/src/test/java/de/bmarwell/proximo/pitido/services/ip/PublicIpv6DiscoveryServiceImplTest.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed under the EUPL, Version 1.2 or – as soon they will be approved by the European Commission - subsequent
+ * versions of the EUPL (the "Licence");
+ * You may not use this work except in compliance with the Licence.
+ * You may obtain a copy of the Licence at:
+ *
+ * ${PROJECT_HOME}/LICENSE
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the Licence is
+ * distributed on an "AS IS" basis, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the Licence for the specific language governing permissions and limitations under the Licence.
+ */
+package de.bmarwell.proximo.pitido.services.ip;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.net.URI;
+import java.util.Optional;
+import javax.ws.rs.ProcessingException;
+import javax.ws.rs.client.Client;
+import javax.ws.rs.client.Invocation;
+import javax.ws.rs.client.WebTarget;
+import javax.ws.rs.core.MediaType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+class PublicIpv6DiscoveryServiceImplTest {
+
+    @Mock
+    Client client;
+
+    @Mock
+    WebTarget webTarget;
+
+    @Mock
+    Invocation.Builder requestBuilder;
+
+    PublicIpv6DiscoveryServiceImpl discoveryService;
+
+    @BeforeEach
+    void setUp() {
+        this.discoveryService = new PublicIpv6DiscoveryServiceImpl();
+        this.discoveryService.clientFactory = () -> this.client;
+    }
+
+    private void wireClientChain() {
+        when(this.client.target(any(URI.class))).thenReturn(this.webTarget);
+        when(this.webTarget.request(any(MediaType.class))).thenReturn(this.requestBuilder);
+    }
+
+    @Test
+    void discover_firstServiceRespondsWithValidIpv6_returnsThatAddress() {
+        // given
+        wireClientChain();
+        when(this.requestBuilder.get(String.class)).thenReturn("2001:db8::1");
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals("2001:db8::1", result.get());
+        verify(this.client, times(1)).target(PublicIpv6DiscoveryServiceImpl.DISCOVERY_URLS.getFirst());
+    }
+
+    @Test
+    void discover_firstServiceFails_triesNextAndReturnsItsAddress() {
+        // given
+        wireClientChain();
+        when(this.requestBuilder.get(String.class))
+                .thenThrow(new ProcessingException("connection refused"))
+                .thenReturn("2001:db8::2");
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals("2001:db8::2", result.get());
+    }
+
+    @Test
+    void discover_allServicesFail_returnsEmpty() {
+        // given
+        wireClientChain();
+        when(this.requestBuilder.get(String.class)).thenThrow(new ProcessingException("no route to host"));
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertFalse(result.isPresent());
+    }
+
+    @Test
+    void discover_serviceReturnsInvalidBody_skipsToNextService() {
+        // given
+        wireClientChain();
+        when(this.requestBuilder.get(String.class))
+                .thenReturn("not-an-ip-address")
+                .thenReturn("2001:db8::3");
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals("2001:db8::3", result.get());
+    }
+
+    @Test
+    void discover_secondCallWithinCacheWindow_doesNotQueryRemoteServices() {
+        // given
+        wireClientChain();
+        when(this.requestBuilder.get(String.class)).thenReturn("2001:db8::1");
+        this.discoveryService.discover();
+
+        // when
+        Optional<String> cached = this.discoveryService.discover();
+
+        // then
+        assertTrue(cached.isPresent());
+        assertEquals("2001:db8::1", cached.get());
+        verify(this.client, times(1)).target(any(URI.class));
+    }
+
+    @Test
+    void discover_responseWithTrailingNewline_isStrippedAndAccepted() {
+        // given
+        wireClientChain();
+        when(this.requestBuilder.get(String.class)).thenReturn("2001:db8::1\n");
+
+        // when
+        Optional<String> result = this.discoveryService.discover();
+
+        // then
+        assertTrue(result.isPresent());
+        assertEquals("2001:db8::1", result.get());
+    }
+
+    @Test
+    void discover_firstServiceSucceeds_doesNotQueryFurtherServices() {
+        // given
+        wireClientChain();
+        when(this.requestBuilder.get(String.class)).thenReturn("2001:db8::1");
+
+        // when
+        this.discoveryService.discover();
+
+        // then
+        verify(this.client, never()).target(PublicIpv6DiscoveryServiceImpl.DISCOVERY_URLS.get(1));
+    }
+
+    @Test
+    void isValidPublicIpv6Address_rejectsIpv4Address() {
+        // given / when / then
+        assertFalse(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address("1.2.3.4"));
+    }
+
+    @Test
+    void isValidPublicIpv6Address_rejectsHostname() {
+        // given / when / then
+        assertFalse(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address("example.com"));
+    }
+
+    @Test
+    void isValidPublicIpv6Address_rejectsBracketedAddress() {
+        // given / when / then
+        assertFalse(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address("[2001:db8::1]"));
+    }
+
+    @Test
+    void isValidPublicIpv6Address_rejectsNull() {
+        // given / when / then
+        assertFalse(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address(null));
+    }
+
+    @Test
+    void isValidPublicIpv6Address_rejectsBlank() {
+        // given / when / then
+        assertFalse(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address("  "));
+    }
+
+    @Test
+    void isValidPublicIpv6Address_acceptsFullAddress() {
+        // given / when / then
+        assertTrue(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address("2001:db8:0:0:0:0:0:1"));
+    }
+
+    @Test
+    void isValidPublicIpv6Address_acceptsCompressedAddress() {
+        // given / when / then
+        // Both compressed ("2001:db8::1") and expanded ("2001:db8:0:0:0:0:0:1") forms are valid.
+        // The validation does not require the input to survive a JVM normalisation round-trip.
+        assertTrue(PublicIpv6DiscoveryServiceImpl.isValidPublicIpv6Address("2001:db8::1"));
+    }
+}

--- a/services/pom.xml
+++ b/services/pom.xml
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.1.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.1.0 https://maven.apache.org/xsd/maven-4.1.0.xsd">
+  <modelVersion>4.1.0</modelVersion>
+
+  <parent>
+    <groupId>de.bmarwell.proximo.pitido</groupId>
+    <artifactId>proximo-pitido</artifactId>
+  </parent>
+
+  <artifactId>proximo-pitido-services</artifactId>
+  <version>1.0.0-SNAPSHOT</version>
+
+  <packaging>pom</packaging>
+
+  <name>Proximo Pitido :: Services</name>
+
+  <description>Service modules: public-facing interfaces (api) and implementations (ip, …).</description>
+
+  <subprojects>
+    <subproject>api</subproject>
+    <subproject>ip</subproject>
+  </subprojects>
+</project>

--- a/war/pom.xml
+++ b/war/pom.xml
@@ -60,6 +60,11 @@
     </dependency>
     <dependency>
       <groupId>de.bmarwell.proximo.pitido</groupId>
+      <artifactId>proximo-pitido-services-ip</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.bmarwell.proximo.pitido</groupId>
       <artifactId>proximo-pitido-codecs-input</artifactId>
       <version>1.0.0-SNAPSHOT</version>
     </dependency>

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/SipRegistrationListener.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/SipRegistrationListener.java
@@ -517,7 +517,7 @@ public class SipRegistrationListener {
 
     private Address buildContactAddress(SipFactory sipFactory) {
         String host = localSipHostProvider.get();
-        String sipHost = host.contains(":") ? "[" + host + "]" : host;
+        String sipHost = host.contains(":") && !host.startsWith("[") ? "[" + host + "]" : host;
 
         return sipFactory.createAddress(sipFactory.createSipURI(this.sipId.orElse(""), sipHost));
     }

--- a/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/SipRegistrationListener.java
+++ b/war/src/main/java/de/bmarwell/proximo/pitido/war/listener/SipRegistrationListener.java
@@ -516,7 +516,10 @@ public class SipRegistrationListener {
     }
 
     private Address buildContactAddress(SipFactory sipFactory) {
-        return sipFactory.createAddress(sipFactory.createSipURI(this.sipId.orElse(""), localSipHostProvider.get()));
+        String host = localSipHostProvider.get();
+        String sipHost = host.contains(":") ? "[" + host + "]" : host;
+
+        return sipFactory.createAddress(sipFactory.createSipURI(this.sipId.orElse(""), sipHost));
     }
 
     private String buildAuthHeader(SipServletResponse challengeResponse) {


### PR DESCRIPTION
## Summary

Closes #50.

Adds IPv6 public-IP discovery and a tri-state configuration for each IP family.

## New module layout

```
services/                         (parent, pom packaging)
  api/                            (proximo-pitido-services-api)
    PublicIpv4DiscoveryService    — interface, for future IPv4 migration
    PublicIpv6DiscoveryService    — interface; discover() returns bare IPv6 literal
  ip/                             (proximo-pitido-services-ip)
    PublicIpv6DiscoveryServiceImpl — @ApplicationScoped; queries v6.ident.me + api6.ipify.org
```

`services-api` has **no container dependencies** (pure Java interfaces).
`services-ip` implements the interface with CDI + JAX-RS; results are cached for 1 hour.

## Tri-state IP family config

| Env var | MP Config property | Default |
|---|---|---|
| `SIP_PUBLIC_IPV4` | `sip.public.ipv4` | `auto` |
| `SIP_PUBLIC_IPV6` | `sip.public.ipv6` | `disabled` |

Values:
- `disabled` — skip this IP family
- `auto` — query the discovery service
- anything else — used as a literal IP address (no network call)

## Address resolution priority in `LocalSipHostProvider`

1. `sip.public.host` (unchanged backward-compat override)
2. IPv6 mode (if not disabled)
3. IPv4 mode (if not disabled)
4. Outbound-interface auto-detection via DatagramSocket routing
5. First non-loopback IPv4 on a live NIC

## SIP URI bracket handling

`SipRegistrationListener.buildContactAddress()` now wraps any host containing `:` in square brackets (`sip:user@[2001:db8::1]`) per RFC 3261 §19.1.1.

## DS-Lite usage

Set `SIP_PUBLIC_IPV6=auto` and `SIP_PUBLIC_IPV4=disabled` on a DS-Lite connection where no public IPv4 is available.

## Dependency changes

- `core` gains a compile dep on `services-api`
- `war` gains a runtime dep on `services-ip`
- `war` gets `services-api` transitively via `core`