### PR TITLE
fix: remove sealed from PublicIpDiscoveryService (Weld proxy incompatibility)

### DIFF
--- a/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpDiscoveryService.java
+++ b/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpDiscoveryService.java
@@ -16,17 +16,24 @@ import java.net.InetAddress;
 import java.util.Optional;
 
 /**
- * Sealed root contract for public-IP discovery services.
+ * Root contract for public-IP discovery services.
  *
- * <p>The two permitted sub-interfaces — {@link PublicIpv4DiscoveryService} and
+ * <p>The two sub-interfaces — {@link PublicIpv4DiscoveryService} and
  * {@link PublicIpv6DiscoveryService} — specialise this contract for each address family.
- * Callers that need to handle both families can use a switch expression over the
- * sub-interface type.
+ * Callers inject the appropriate sub-interface directly; this base interface exists only
+ * to share the {@link #discover()} contract.
+ *
+ * <p>Note: this interface is intentionally <em>not</em> sealed.
+ * Weld (CDI 2.0, used by Open Liberty) generates client-proxy subclasses at runtime
+ * for every {@code @ApplicationScoped} bean.
+ * If this interface were sealed, the JVM would reject those generated proxies with an
+ * {@code IncompatibleClassChangeError} because the proxy class is not in the {@code permits}
+ * list.
  *
  * <p>Implementations query remote IP-echo services and cache the result.
  * When all services are unreachable, {@link Optional#empty()} is returned.
  */
-public sealed interface PublicIpDiscoveryService permits PublicIpv4DiscoveryService, PublicIpv6DiscoveryService {
+public interface PublicIpDiscoveryService {
 
     /**
      * Returns the public IP address of this host.

--- a/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpv4DiscoveryService.java
+++ b/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpv4DiscoveryService.java
@@ -28,7 +28,7 @@ import java.util.Optional;
  * without coupling to any specific implementation.
  * The implementation is provided at runtime by {@code proximo-pitido-services-ip}.
  */
-public non-sealed interface PublicIpv4DiscoveryService extends PublicIpDiscoveryService {
+public interface PublicIpv4DiscoveryService extends PublicIpDiscoveryService {
 
     /**
      * Returns the public IPv4 address of this host.

--- a/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpv6DiscoveryService.java
+++ b/services/api/src/main/java/de/bmarwell/proximo/pitido/services/api/PublicIpv6DiscoveryService.java
@@ -30,7 +30,7 @@ import java.util.Optional;
  * Callers that embed the address in a SIP URI must format it with square brackets
  * ({@code sip:user@[2001:db8::1]}) per RFC 3261 §19.1.1.
  */
-public non-sealed interface PublicIpv6DiscoveryService extends PublicIpDiscoveryService {
+public interface PublicIpv6DiscoveryService extends PublicIpDiscoveryService {
 
     /**
      * Returns the public IPv6 address of this host.


### PR DESCRIPTION
## Problem

After merging #121, Open Liberty failed to start with:

```
IncompatibleClassChangeError: class …PublicIpv4DiscoveryServiceImpl$Proxy$_$$_WeldClientProxy
is not permitted to inherit from its sealed super interface.
```

Weld (CDI 2.0) generates a client-proxy subclass at runtime for every `@ApplicationScoped` bean.
Since `PublicIpDiscoveryService` was declared `sealed` (permitting only the two sub-interfaces), the JVM rejected the dynamically generated proxy class because it is not in the `permits` list.
Sealed interfaces and Weld proxy generation are fundamentally incompatible.

## Fix

Remove `sealed`/`non-sealed` from `PublicIpDiscoveryService`, `PublicIpv4DiscoveryService`, and `PublicIpv6DiscoveryService`.

Injection-point type safety is preserved: `LocalSipHostProvider` injects the specific sub-interface (`PublicIpv4DiscoveryService` or `PublicIpv6DiscoveryService`), so CDI still resolves unambiguously.
A Javadoc note explains why `sealed` is intentionally absent.

Fixes the startup regression introduced by #121.